### PR TITLE
Add home alone "summer" strategy

### DIFF
--- a/gw_spaceheat/actors/home_alone/home_alone_tou_base.py
+++ b/gw_spaceheat/actors/home_alone/home_alone_tou_base.py
@@ -67,7 +67,6 @@ class HomeAloneTouBase(ScadaActor):
         self.hardware_layout = self._services.hardware_layout
         
         self.time_since_blind: Optional[float] = None
-        self.relays_initialized = False
         self.scadablind_scada = False
         self.scadablind_boiler = False
         
@@ -97,6 +96,7 @@ class HomeAloneTouBase(ScadaActor):
             raise Exception(f"HomeAlone requires {H0N.home_alone_onpeak_backup} node!!")
         self.set_command_tree(boss_node=self.normal_node)
         self.latest_temperatures: Dict[str, int] = {} # 
+        self.actuators_initialized = False
         self.actuators_ready = False
 
     @property
@@ -175,7 +175,7 @@ class HomeAloneTouBase(ScadaActor):
             raise Exception(f"Unknown top event {cause}")
         
         if self.top_state == HomeAloneTopState.Dormant:
-            self.relays_initialized = False
+            self.actuators_initialized = False
 
         self._send_to(
             self.primary_scada,
@@ -293,7 +293,7 @@ class HomeAloneTouBase(ScadaActor):
 
     def initialize_actuators(self):
         if not self.actuators_ready:
-            self.log(f"Waiting to initialize actuators until they are ready!")
+            self.log(f"Waiting to initialize actuators until actuator drivers are ready!")
             return
         self.log("Initializing relays")
         if self.top_state != HomeAloneTopState.Normal:
@@ -336,7 +336,7 @@ class HomeAloneTouBase(ScadaActor):
             self.set_010_defaults()
         except ValueError as e:
             self.log(f"Trouble with set_010_defaults: {e}")
-        self.relays_initialized = True
+        self.actuators_initialized = True
 
     def trigger_house_cold_onpeak_event(self) -> None:
         """

--- a/gw_spaceheat/actors/home_alone/shoulder_tou.py
+++ b/gw_spaceheat/actors/home_alone/shoulder_tou.py
@@ -166,7 +166,7 @@ class ShoulderTouHomeAlone(HomeAloneTouBase):
             self.alert("BadHomeAloneState", "TopState Normal, state Dormant!")
             self.trigger_normal_event(HaShoulderEvent.WakeUp)
 
-        if not self.relays_initialized:
+        if not self.actuators_initialized:
             self.initialize_actuators()
 
         previous_state = self.state

--- a/gw_spaceheat/actors/home_alone/summer.py
+++ b/gw_spaceheat/actors/home_alone/summer.py
@@ -1,0 +1,194 @@
+import asyncio
+from enum import auto
+from typing import List, Optional, Sequence
+import time
+from actors.scada_interface import ScadaInterface
+from data_classes.house_0_names import H0N
+from enums import HomeAloneStrategy
+from gw.enums import GwStrEnum
+from gwproactor import MonitoredName
+from gwproactor.message import PatInternalWatchdogMessage
+
+from gwproto.enums import ActorClass
+from gwproto import Message
+from result import Ok, Result
+from named_types import SingleMachineState
+from gwproto.data_classes.sh_node import ShNode
+from transitions import Machine
+from actors.scada_actor import ScadaActor
+from actors.scada_interface import ScadaInterface
+from named_types import ActuatorsReady, GoDormant, HeatingForecast, WakeUp
+
+class SummerTopState(GwStrEnum):
+    EverythingOff = auto()
+    Dormant = auto()
+
+    @classmethod
+    def enum_name(cls) -> str:
+        return "summer.top.state"
+
+    @classmethod
+    def values(cls) -> List[str]:
+        return [elt.value for elt in cls]
+
+
+class SummerTopEvent(GwStrEnum):
+    TopGoDormant = auto()
+    TopWakeUp = auto()
+
+    @classmethod
+    def enum_name(cls) -> str:
+        return "summer.top.event"
+
+
+class SummerHomeAlone(ScadaActor):
+    MAIN_LOOP_SLEEP_SECONDS = 300
+    top_states = SummerTopState.values()
+
+    top_transitions = [
+            {"trigger": "TopGoDormant", "source": "EverythingOff", "dest": "Dormant"},
+            {"trigger": "TopWakeUp", "source": "Dormant", "dest": "EverythingOff"},
+    ]   
+
+    def __init__(self, name: str, services: ScadaInterface):
+        super().__init__(name, services)
+        self.strategy = HomeAloneStrategy(getattr(self.node, "Strategy", None))
+        if self.strategy != HomeAloneStrategy.Summer:
+            raise Exception(
+                f"Expect ShoulderTou Summer, got {self.strategy}"
+            )
+        self._stop_requested: bool = False
+        self.buffer_declared_ready = False
+        self.full_buffer_energy: Optional[float] = None  # in kWh
+
+        self.top_machine = Machine(
+            model=self,
+            states=SummerHomeAlone.top_states,
+            transitions=SummerHomeAlone.top_transitions,
+            initial=SummerTopState.EverythingOff,
+            send_event=True,
+            model_attribute="top_state"
+        )
+        self.top_state: SummerTopState = SummerTopState.EverythingOff
+        self.set_command_tree(boss_node=self.normal_node)
+        self.actuators_ready = False
+
+    def trigger_top_event(self, cause: SummerTopEvent) -> None:
+        """
+        Trigger top event. Set relays_initialized to False if top state
+        is Dormant. Report state change.
+        """
+        now_ms = int(time.time() * 1000)
+        orig_state = self.top_state
+        if cause == SummerTopEvent.TopGoDormant:
+            self.TopGoDormant()
+        elif cause == SummerTopEvent.TopWakeUp:
+            self.TopWakeUp()
+        
+        if self.top_state == SummerTopState.Dormant:
+            self.relays_initialized = False
+
+        self._send_to(
+            self.primary_scada,
+            SingleMachineState(
+                MachineHandle=self.node.handle,
+                StateEnum=SummerTopState.enum_name(),
+                State=self.top_state,
+                UnixMs=now_ms,
+                Cause=cause.value,
+            ),
+        )
+        self.log(f"{cause}: {orig_state} -> {self.top_state}")
+        self.log("Set top state command tree")
+
+    @property
+    def normal_node(self) -> ShNode:
+        return self.layout.node(H0N.home_alone_normal)
+
+    def initialize_actuators(self) -> None:
+        if not self.actuators_ready:
+            self.log(f"Waiting to initialize actuators until actuator drivers are ready")
+            return
+        if self.top_state != SummerTopState.EverythingOff:
+            raise Exception("Can not go into update_relays if top state is not EverythingOff")
+        
+        self.log("Initializing relays")
+        h_normal_relays =  {
+            relay
+            for relay in self.my_actuators()
+            if relay.ActorClass == ActorClass.Relay and
+            self.the_boss_of(relay) == self.normal_node
+        }
+
+        relays_to_energize = {
+            self.hp_failsafe_relay,
+            self.hp_scada_ops_relay, 
+            self.aquastat_control_relay,
+            self.hp_loop_on_off,
+        }
+
+        target_relays: List[ShNode] = list(h_normal_relays - relays_to_energize)
+        target_relays.sort(key=lambda x: x.Name)
+        self.log("de-energizing most relays")
+        for relay in target_relays:
+            self.de_energize(relay, from_node=self.normal_node)
+
+        self.log("energizing key relays for keeping things off")
+        for relay in relays_to_energize:
+            self.energize(relay, from_node=self.normal_node)
+        
+    def start(self) -> None:
+        ...
+
+    def stop(self) -> None:
+        self._stop_requested = True
+
+    async def join(self):
+        ...
+
+    def process_message(self, message: Message) -> Result[bool, BaseException]:
+        from_node = self.layout.node(message.Header.Src, None)
+        match message.Payload:
+            case ActuatorsReady():
+                self.process_actuators_ready(from_node, message.Payload)
+            case GoDormant():
+                if len(self.my_actuators()) > 0:
+                    raise Exception("HomeAlone sent GoDormant with live actuators under it!")
+                if self.top_state != SummerTopState.Dormant:
+                    # TopGoDormant: Normal/UsingBackupOnpeak -> Dormant
+                    self.trigger_top_event(cause=SummerTopEvent.TopGoDormant)
+            case WakeUp():
+                try:
+                    self.process_wake_up(from_node, message.Payload)
+                except Exception as e:
+                    self.log(f"Trouble with process_wake_up: {e}")
+            case HeatingForecast():
+                ... # Ignore this
+
+        return Ok(True)
+    
+    def process_actuators_ready(self, from_node: ShNode, payload: ActuatorsReady) -> None:
+        """Initialize actuators if that hasn't happened yet"""
+        if not self.actuators_ready:
+            self.actuators_ready = True
+            self.initialize_actuators()
+
+    def process_wake_up(self, from_node: ShNode, payload: WakeUp) -> None:
+        if self.top_state != SummerTopState.Dormant:
+            return
+        # TopWakeUp: Dormant -> EverythingOff
+        self.trigger_top_event(SummerTopEvent.TopWakeUp)
+        self.set_command_tree(boss_node=self.normal_node)
+        # Set actuators the way they need to be
+        self.log(f"TopWakeUp: Dormant -> EverythingOff")
+        self.initialize_actuators()
+
+    @property
+    def monitored_names(self) -> Sequence[MonitoredName]:
+        return [MonitoredName(self.name, self.MAIN_LOOP_SLEEP_SECONDS * 2.1)]
+
+    async def main(self):
+        while not self._stop_requested:
+            self._send(PatInternalWatchdogMessage(src=self.name))
+            await asyncio.sleep(self.MAIN_LOOP_SLEEP_SECONDS)
+            self.log(f"State: {self.top_state}")

--- a/gw_spaceheat/actors/home_alone/winter_tou.py
+++ b/gw_spaceheat/actors/home_alone/winter_tou.py
@@ -197,7 +197,7 @@ class WinterTouHomeAlone(HomeAloneTouBase):
             self.alert("BadHomeAloneState", "TopState Normal, state Dormant!")
             self.trigger_normal_event(HaWinterEvent.WakeUp)
         
-        if not self.relays_initialized:
+        if not self.actuators_initialized:
             self.initialize_actuators()
 
         previous_state = self.state

--- a/gw_spaceheat/actors/home_alone_loader.py
+++ b/gw_spaceheat/actors/home_alone_loader.py
@@ -23,6 +23,9 @@ class HomeAlone(ScadaActor):
         elif strategy == HomeAloneStrategy.ShoulderTou:
             module = importlib.import_module("actors.home_alone.shoulder_tou")
             impl_class = getattr(module, "ShoulderTouHomeAlone")
+        elif strategy == HomeAloneStrategy.Summer:
+            module = importlib.import_module("actors.home_alone.summer")
+            impl_class = getattr(module, "SummerHomeAlone")
         else:
             raise Exception(f"Unknown strategy {strategy}")
 

--- a/gw_spaceheat/actors/scada.py
+++ b/gw_spaceheat/actors/scada.py
@@ -838,7 +838,6 @@ class Scada(ScadaInterface, Proactor):
     def auto_trigger(self, trigger: MainAutoEvent) -> None:
         """ Pulls trigger, updates command tree and sends appropriate messages
         """
-        self.log("In auto_trigger")
         if trigger == MainAutoEvent.DispatchContractLive:
             if self.auto_state != MainAutoState.HomeAlone:
                 self.log(f"Ignoring DispatchContractLive tigger in auto_state {self.auto_state}")
@@ -885,9 +884,9 @@ class Scada(ScadaInterface, Proactor):
             if self.auto_state == MainAutoState.Dormant:
                 self.log(f"Ignoring AutoWakesUp trigger in auto_state {self.auto_state}")
                 return
+            prev_state = self.auto_state
             self.AutoGoesDormant()
-            self.log(f"AutoGoesDormant: {self.auto_state} -> Dormant")
-            self.log(f"auto_state {self.auto_state}")
+            self.log(f"AutoGoesDormant: {prev_state} -> {self.auto_state}")
             # ADMIN CONTROL FOREST: a single tree, controlling all actuators
             self.set_command_tree(self.admin)
 

--- a/gw_spaceheat/actors/synth_generator.py
+++ b/gw_spaceheat/actors/synth_generator.py
@@ -182,8 +182,13 @@ class SynthGenerator(ScadaActor):
 
     # Compute usable and required energy
     def update_energy(self) -> None:
+        
         time_now = datetime.now(self.timezone)
         latest_temperatures = self.latest_temperatures.copy()
+
+        if self.layout.ha_strategy in [HomeAloneStrategy.Summer]:
+            #self.log(f"Does not calculate usable/required energy in {self.layout.ha_strategy} ")
+            return
 
         if self.layout.ha_strategy == HomeAloneStrategy.WinterTou:
             storage_temperatures = {k:v for k,v in latest_temperatures.items() if 'tank' in k}

--- a/gw_spaceheat/enums/home_alone_strategy.py
+++ b/gw_spaceheat/enums/home_alone_strategy.py
@@ -9,6 +9,7 @@ class HomeAloneStrategy(GwStrEnum):
     Values:
       - WinterTou
       - ShoulderTou
+      - Summer
 
     For more information:
       - [ASLs](https://gridworks-type-registry.readthedocs.io/en/latest/)
@@ -16,7 +17,7 @@ class HomeAloneStrategy(GwStrEnum):
     """
     WinterTou = auto()
     ShoulderTou = auto()
-
+    Summer = auto()
 
     @classmethod
     def default(cls) -> "HomeAloneStrategy":
@@ -32,4 +33,4 @@ class HomeAloneStrategy(GwStrEnum):
 
     @classmethod
     def enum_version(cls) -> str:
-        return "000"
+        return "001"


### PR DESCRIPTION
 - energizes relays needed to keep both oil boiler and heat pump off (5,6,8).
 - also energizes siegenthaler relay that starts trying to move the siegenthaler valve
 - simplifies energize/de_energize relay method
 - atomic ally refuses to enter dispatch contracts
 - don't calculate usable and required energy in summer mode

relays_initialized -> actuators_initialized (minor)