### PR TITLE
Admin leak improvements

### DIFF
--- a/gw_spaceheat/admin/cli.py
+++ b/gw_spaceheat/admin/cli.py
@@ -32,12 +32,14 @@ def watch_settings(
     target: str = "",
     env_file: str = ".env",
     verbose: int = 0,
-    paho_verbose: int = 0
+    paho_verbose: int = 0,
+    show_clock: bool = False,
 ) -> AdminClientSettings:
     # https://github.com/koxudaxi/pydantic-pycharm-plugin/issues/1013
     # noinspection PyArgumentList
     settings = AdminClientSettings(
         _env_file=dotenv.find_dotenv(env_file),
+        show_clock=show_clock,
     ).update_paths_name("admin")
     if target:
         settings.target_gnode = target
@@ -72,10 +74,23 @@ def watch(
         typer.Option(
             "--paho-verbose", count=True
         )
-    ] = 0
+    ] = 0,
+    show_clock: Annotated[
+        bool,
+        typer.Option(
+            "--show-clock",
+        )
+    ] = False,
+
 ) -> None:
     """Watch and set relays."""
-    settings = watch_settings(target, env_file, verbose, paho_verbose)
+    settings = watch_settings(
+        target,
+        env_file,
+        verbose,
+        paho_verbose,
+        show_clock=show_clock,
+    )
     rich.print(settings)
     watch_app = RelaysApp(settings=settings)
     watch_app.run()

--- a/gw_spaceheat/admin/settings.py
+++ b/gw_spaceheat/admin/settings.py
@@ -16,6 +16,7 @@ class AdminClientSettings(AppSettings):
     link: MQTTClient = MQTTClient()
     verbosity: int = logging.WARN
     paho_verbosity: Optional[int] = None
+    show_clock: bool = False
     model_config = SettingsConfigDict(
         env_prefix="GWADMIN_",
         env_nested_delimiter="__",

--- a/gw_spaceheat/admin/watch/clients/admin_client.py
+++ b/gw_spaceheat/admin/watch/clients/admin_client.py
@@ -142,8 +142,8 @@ class AdminClient:
             await asyncio.sleep(60)
             if self._layout is None:
                 self._request_layout_lite()
-            elif self._snap is None:
-                self._request_snapshot()
+            elif self._snap is None:  # noqa
+                self._request_snapshot()  # noqa
 
     def start(self):
         self._paho_wrapper.start()

--- a/gw_spaceheat/admin/watch/clients/constrained_mqtt_client.py
+++ b/gw_spaceheat/admin/watch/clients/constrained_mqtt_client.py
@@ -190,7 +190,7 @@ class ConstrainedMQTTClient:
                 self._stop_requested = False
                 self._thread = threading.Thread(
                     target=self._client_thread,
-                    name=f"admin-MQTT-client-thread"
+                    name="admin-MQTT-client-thread"
                 )
                 self._thread.start()
 

--- a/gw_spaceheat/admin/watch/clients/relay_client.py
+++ b/gw_spaceheat/admin/watch/clients/relay_client.py
@@ -204,7 +204,7 @@ class RelayWatchClient(AdminSubClient):
 
     def process_layout_lite(self, layout: LayoutLite) -> None:
         config_changes = self._update_layout(layout)
-        if config_changes and self._callbacks.relay_config_change_callback:
+        if config_changes and self._callbacks.relay_config_change_callback is not None:
             self._callbacks.relay_config_change_callback(config_changes)
         if self._callbacks.layout_callback is not None:
             self._callbacks.layout_callback(layout)

--- a/gw_spaceheat/admin/watch/relay_app.py
+++ b/gw_spaceheat/admin/watch/relay_app.py
@@ -66,7 +66,7 @@ class RelaysApp(App):
         self.set_reactive(RelaysApp.sub_title, self.settings.target_gnode)
 
     def compose(self) -> ComposeResult:
-        yield Header(show_clock=True)
+        yield Header(show_clock=self.settings.show_clock)
         relays = Relays(logger=logger, id="relays")
         self._relay_client.set_callbacks(relays.relay_client_callbacks())
         yield relays

--- a/gw_spaceheat/admin/watch/relay_app.py
+++ b/gw_spaceheat/admin/watch/relay_app.py
@@ -70,7 +70,8 @@ class RelaysApp(App):
         relays = Relays(logger=logger, id="relays")
         self._relay_client.set_callbacks(relays.relay_client_callbacks())
         yield relays
-        yield Footer()
+        # Disable as defense against memory leaks
+        # yield Footer()
 
     def on_mount(self) -> None:
         self._admin_client.start()

--- a/gw_spaceheat/admin/watch/widgets/mqtt.py
+++ b/gw_spaceheat/admin/watch/widgets/mqtt.py
@@ -38,8 +38,10 @@ class MqttState(Widget):
 
     def render(self) -> str:
         return (
-            f"MQTT broker connection: {self.mqtt_state:12s}  "
-            f"Messages received: {self.message_count}  "
-            f"Snapshots: {self.snapshot_count}  "
-            f"Layouts: {self.layout_count}"
+            f"MQTT broker connection: {self.mqtt_state:12s}"
+
+            # Counters disabled as defense against memory leaks:
+            # f"  Messages received: {self.message_count}  "
+            # f"Snapshots: {self.snapshot_count}  "
+            # f"Layouts: {self.layout_count}"
         )

--- a/gw_spaceheat/admin/watch/widgets/relays.py
+++ b/gw_spaceheat/admin/watch/widgets/relays.py
@@ -1,11 +1,7 @@
-import datetime
-import json
 import logging
 import sys
 from logging import Logger
 from typing import Optional
-
-from gwproto import MQTTTopic
 
 from textual.app import ComposeResult
 from textual.containers import HorizontalGroup
@@ -14,27 +10,25 @@ from textual.logging import TextualHandler
 from textual.messages import Message
 from textual.reactive import Reactive
 from textual.reactive import reactive
-
 from textual.widget import Widget
 from textual.widgets import DataTable
-from textual.widgets._data_table import CellType # noqa
+from textual.widgets._data_table import CellType  # noqa
 
-from admin.watch.clients.admin_client import type_name
 from admin.watch.clients.constrained_mqtt_client import ConstrainedMQTTClient
 from admin.watch.clients.relay_client import ObservedRelayStateChange
 from admin.watch.clients.relay_client import RelayClientCallbacks
 from admin.watch.clients.relay_client import RelayConfigChange
 from admin.watch.widgets.keepalive import KeepAliveButton
 from admin.watch.widgets.keepalive import ReleaseControlButton
-from admin.watch.widgets.timer import TimerDigits
-from admin.watch.widgets.time_input import TimeInput
 from admin.watch.widgets.mqtt import Mqtt
 from admin.watch.widgets.mqtt import MqttState
 from admin.watch.widgets.relay_toggle_button import RelayToggleButton
 from admin.watch.widgets.relay_widget_info import RelayWidgetConfig
 from admin.watch.widgets.relay_widget_info import RelayWidgetInfo
-
-from named_types import LayoutLite, SnapshotSpaceheat
+from admin.watch.widgets.time_input import TimeInput
+from admin.watch.widgets.timer import TimerDigits
+from named_types import LayoutLite
+from named_types import SnapshotSpaceheat
 
 module_logger = logging.getLogger(__name__)
 module_logger.addHandler(TextualHandler())
@@ -202,7 +196,7 @@ class Relays(Widget):
         self._update_relay_row(message.row_key.value)
         self._update_buttons(message.row_key.value)
 
-    def on_relays_layout(self, message: Layout) -> None:
+    def on_relays_layout(self, message: Layout) -> None:  # noqa
         self.query_one(MqttState).message_count += 1
         self.query_one(MqttState).layout_count += 1
         # self.query_one("#message_table", DataTable).add_row(
@@ -212,7 +206,7 @@ class Relays(Widget):
         # )
         # self.query_one("#message_table", DataTable).scroll_end()
 
-    def on_relays_snapshot(self, message: Snapshot) -> None:
+    def on_relays_snapshot(self, message: Snapshot) -> None:  # noqa
         self.query_one(MqttState).message_count += 1
         self.query_one(MqttState).snapshot_count += 1
         # self.query_one("#message_table", DataTable).add_row(
@@ -225,9 +219,9 @@ class Relays(Widget):
     def on_mqtt_state_change(self, message: Mqtt.StateChange):
         self.query_one(MqttState).mqtt_state = message.new_state
 
-    def on_mqtt_receipt(self, message: Mqtt.Receipt):
+    def on_mqtt_receipt(self, message: Mqtt.Receipt):  # noqa
         self.query_one(MqttState).message_count += 1
-        payload = json.loads(message.payload.decode("utf-8"))
+        # payload = json.loads(message.payload.decode("utf-8"))
         # self.query_one("#message_table", DataTable).add_row(
         #     datetime.datetime.now(),
         #     MQTTTopic.decode(message.topic).message_type,

--- a/gw_spaceheat/admin/watch/widgets/relays.py
+++ b/gw_spaceheat/admin/watch/widgets/relays.py
@@ -237,11 +237,12 @@ class Relays(Widget):
     def relay_client_callbacks(self) -> RelayClientCallbacks:
         return RelayClientCallbacks(
             mqtt_state_change_callback=self.mqtt_state_change_callback,
-            mqtt_message_received_callback=self.mqtt_receipt_callback,
             relay_state_change_callback=self.relay_state_change_callback,
             relay_config_change_callback=self.relay_config_change_callback,
-            layout_callback=self.layout_callback,
-            snapshot_callback=self.snapshot_callback,
+            # disable these as defense against memroy leaks
+            mqtt_message_received_callback=None,
+            layout_callback=None,
+            snapshot_callback=None,
         )
 
     def relay_state_change_callback(self, changes: dict[str, ObservedRelayStateChange]) -> None:

--- a/gw_spaceheat/admin/watch/widgets/relays.py
+++ b/gw_spaceheat/admin/watch/widgets/relays.py
@@ -190,7 +190,6 @@ class Relays(Widget):
             "#relay_toggle_button_container",
             HorizontalGroup,
         ).border_title = relay_info.config.table_name.border_title
-        self.refresh_bindings()
 
     def on_data_table_row_highlighted(self, message: DataTable.RowHighlighted) -> None:
         self._update_relay_row(message.row_key.value)

--- a/gw_spaceheat/requirements/base.in
+++ b/gw_spaceheat/requirements/base.in
@@ -21,5 +21,5 @@ pyModbusTCP
 rich
 typer
 trogon
-textual>=1.0.0
+textual>=5.3.0
 textual-dev

--- a/gw_spaceheat/requirements/base.txt
+++ b/gw_spaceheat/requirements/base.txt
@@ -89,8 +89,10 @@ pydantic-extra-types==2.9.0
     # via gridworks-protocol
 pydantic-settings==2.4.0
     # via gridworks-proactor
-pygments==2.14.0
-    # via rich
+pygments==2.19.2
+    # via
+    #   rich
+    #   textual
 pymodbus==3.1.1
     # via -r gw_spaceheat/requirements/base.in
 pymodbustcp==0.2.0
@@ -124,7 +126,7 @@ six==1.16.0
     # via transitions
 smbus2==0.4.2
     # via -r gw_spaceheat/requirements/base.in
-textual==1.0.0
+textual==5.3.0
     # via
     #   -r gw_spaceheat/requirements/base.in
     #   textual-dev

--- a/gw_spaceheat/requirements/dev.in
+++ b/gw_spaceheat/requirements/dev.in
@@ -6,3 +6,4 @@ isort
 gridworks-cert>=0.4.4
 gridworks-proactor[tests] ~= 4.1.9
 requests # for atn dashboard
+memray

--- a/gw_spaceheat/requirements/dev.txt
+++ b/gw_spaceheat/requirements/dev.txt
@@ -162,6 +162,7 @@ pygments==2.19.2
     # via
     #   pytest
     #   rich
+    #   textual
 pymodbus==3.9.2
     # via -r gw_spaceheat/requirements/base.in
 pymodbustcp==0.3.0
@@ -219,7 +220,7 @@ smbus2==0.5.0
     # via -r gw_spaceheat/requirements/base.in
 sniffio==1.3.1
     # via anyio
-textual==3.5.0
+textual==5.3.0
     # via
     #   -r gw_spaceheat/requirements/base.in
     #   textual-dev

--- a/gw_spaceheat/requirements/dev.txt
+++ b/gw_spaceheat/requirements/dev.txt
@@ -86,6 +86,7 @@ isort==6.0.1
 jinja2==3.1.6
     # via
     #   aiohttp-jinja2
+    #   memray
     #   textual-serve
 linkify-it-py==2.0.3
     # via markdown-it-py
@@ -100,6 +101,8 @@ mdit-py-plugins==0.4.2
     # via markdown-it-py
 mdurl==0.1.2
     # via markdown-it-py
+memray==1.18.0
+    # via -r gw_spaceheat/requirements/dev.in
 msgpack==1.1.1
     # via textual-dev
 multidict==6.5.0
@@ -205,6 +208,7 @@ rich==14.0.0
     #   -r gw_spaceheat/requirements/base.in
     #   gridworks-cert
     #   gridworks-proactor
+    #   memray
     #   textual
     #   textual-serve
     #   typer
@@ -223,6 +227,7 @@ sniffio==1.3.1
 textual==5.3.0
     # via
     #   -r gw_spaceheat/requirements/base.in
+    #   memray
     #   textual-dev
     #   textual-serve
     #   trogon

--- a/gw_spaceheat/requirements/drivers.txt
+++ b/gw_spaceheat/requirements/drivers.txt
@@ -124,8 +124,10 @@ pydantic-settings==2.4.0
     # via gridworks-proactor
 pyftdi==0.56.0
     # via adafruit-blinka
-pygments==2.14.0
-    # via rich
+pygments==2.19.2
+    # via
+    #   rich
+    #   textual
 pymodbus==2.5.3
     # via -r gw_spaceheat/requirements/base.in
 pymodbustcp==0.2.0
@@ -167,7 +169,7 @@ six==1.16.0
     #   transitions
 smbus2==0.4.1
     # via -r gw_spaceheat/requirements/base.in
-textual==1.0.0
+textual==5.3.0
     # via
     #   -r gw_spaceheat/requirements/base.in
     #   textual-dev

--- a/tools/mkenv.sh
+++ b/tools/mkenv.sh
@@ -1,5 +1,6 @@
 
 dev_requirements=gw_spaceheat/requirements/dev.txt
+PYTHON="${PYTHON:-python}"
 
 if [[ ( $@ == "--help") ||  $@ == "-h" ]]
 then
@@ -13,7 +14,7 @@ then
 fi
 
 rm -rf gw_spaceheat/venv
-python -m venv gw_spaceheat/venv
+$PYTHON -m venv gw_spaceheat/venv
 source gw_spaceheat/venv/bin/activate
 which pip
 pip install --upgrade pip


### PR DESCRIPTION
This PR reduces the leak in admin by about a factor of 7, from something like 8-10 MB/hr to something like 1 - 1.3 MB/ hour. 

This reduction is achieved by: 
* Removing a now-unnecessary and frequent call to [refresh_bindings()](https://textual.textualize.io/api/dom_node/#textual.dom.DOMNode.refresh_bindings) which appeared to kick off a lot of code that allocated and didn't free memory when interacting with the footer. 
* Removing the footer display entirely, as it appeared to contribute some memory loss.
* Remove the ticking clock from the header. 
* Disabled passing along of internal textual messages which were only used to show counts of messages received. Removed displays of counts entirely as they would just show 0 which was not correct.

It's still unclear why any of these behaviors leak memory (and much more on linux than on mac) at all.