### PR TITLE
Add test for scada.auto_state home alone -> atn transition

### DIFF
--- a/gw_spaceheat/actors/atomic_ally.py
+++ b/gw_spaceheat/actors/atomic_ally.py
@@ -129,11 +129,11 @@ class AtomicAlly(ScadaActor):
 
     @property
     def remaining_watthours(self) -> Optional[int]:
-        return self.services.contract_handler.remaining_watthours
+        return self.services.scada.contract_handler.remaining_watthours
     
     @property
     def contract_hb(self) -> Optional[SlowContractHeartbeat]:
-        return self.services.contract_handler.latest_scada_hb
+        return self.services.scada.contract_handler.latest_scada_hb
 
     @property
     def params(self) -> Ha1Params:

--- a/gw_spaceheat/actors/power_meter.py
+++ b/gw_spaceheat/actors/power_meter.py
@@ -3,9 +3,7 @@ isolates code used only in PowerMeterDriverThread constructor. """
 import logging
 import time
 import typing
-from typing import Dict
-from typing import List
-from typing import Optional
+from typing import Dict, List, Optional
 
 from gwproactor.logger import LoggerOrAdapter
 from gwproto import Message
@@ -31,7 +29,7 @@ from gwproactor import Problems
 from gwproto.enums import MakeModel
 from gwproto.named_types import ElectricMeterChannelConfig, PowerWatts, SyncedReadings
 
-from scada_app import ScadaApp
+from scada_app_interface import ScadaAppInterface
 
 
 class HWUidMismatch(DriverWarning):
@@ -133,7 +131,6 @@ class PowerMeterDriverThread(SyncAsyncInteractionThread):
     latest_telemetry_value: Dict[DataChannel, Optional[int]]
     _last_sampled_s: Dict[DataChannel, Optional[int]]
     async_power_reporting_threshold: float
-    _telemetry_destination: str
     _hardware_layout: HardwareLayout
     _hw_uid: str = ""
 
@@ -142,7 +139,6 @@ class PowerMeterDriverThread(SyncAsyncInteractionThread):
         node: ShNode,
         settings: ScadaSettings,
         hardware_layout: HardwareLayout,
-        telemetry_destination: str,
         responsive_sleep_step_seconds=0.01,
         daemon: bool = True,
         logger: Optional[LoggerOrAdapter] = None,
@@ -154,7 +150,6 @@ class PowerMeterDriverThread(SyncAsyncInteractionThread):
             logger=logger,
         )
         self._hardware_layout = hardware_layout
-        self._telemetry_destination = telemetry_destination
         setup_helper = DriverThreadSetupHelper(
             node,
             settings,
@@ -392,7 +387,7 @@ class PowerMeter(SyncThreadActor):
     def __init__(
         self,
         name: str,
-        services: ScadaApp,
+        services: ScadaAppInterface,
         settings: Optional[ScadaSettings] = None,
     ):
         settings = settings or services.settings
@@ -403,7 +398,6 @@ class PowerMeter(SyncThreadActor):
                 node=services.hardware_layout.node(name),
                 settings=settings,
                 hardware_layout=services.hardware_layout,
-                telemetry_destination=services.name,
                 logger=services.logger.add_category_logger(
                     self.POWER_METER_LOGGER_NAME,
                     level=settings.power_meter_logging_level,

--- a/tests/actors/test_auto_state.py
+++ b/tests/actors/test_auto_state.py
@@ -1,0 +1,142 @@
+import logging
+import time
+import uuid
+import pytest
+import typing
+from gwproto import Message
+from actors import AtomicAlly
+from data_classes.house_0_names import H0N
+from enums import MainAutoState, ContractStatus
+from named_types import SlowDispatchContract, SlowContractHeartbeat
+from tests.utils.scada_live_test_helper import ScadaLiveTest
+
+
+@pytest.mark.asyncio
+async def test_auto_state_home_alone_to_atn(request: pytest.FixtureRequest) -> None:
+    """Test that auto_state transitions from HomeAlone to Atn when a SlowDispatchContract starts."""
+    
+    async with ScadaLiveTest(
+        request=request,
+    ) as h:
+        h.start_child1() # start primary scada
+        h.start_parent() # start atn
+
+        await h.await_for(
+            lambda: h.child_to_parent_link.active(),
+            "ERROR waiting for scada to atn link"
+        )
+        scada = h.child1_app.scada
+        atn = h.parent_app.atn
+        aa = h.child1_app.get_communicator_as_type(
+                H0N.atomic_ally,
+                AtomicAlly
+            )
+        if aa is None:
+            raise Exception("No aa")
+        # Verify initial state is HomeAlone
+        print("Verifying initial state is HomeAlone")
+        assert scada.auto_state == MainAutoState.HomeAlone, f"Expected HomeAlone, got {scada.auto_state}"
+        
+        # atomic ally will reject contract if it doesn't have forecasts. 
+        # It gets forecasts during startup.
+        await h.await_for(
+            lambda: aa.forecasts is not None,
+            "aa never got forecasts!"
+        )
+
+        # Atn creates a slow dispatch contract and hb to send to SCADA
+        # Round to the nearest 5 minutes for StartS
+        current_time = int(time.time())
+        start_s = (current_time // 300) * 300 + 300  # Next 5-minute boundary
+        
+        contract = SlowDispatchContract(
+            ScadaAlias=atn.layout.scada_g_node_alias,
+            StartS=start_s,
+            DurationMinutes=60,
+            AvgPowerWatts=1000,
+            OilBoilerOn=False,
+            ContractId=str(uuid.uuid4())
+        )
+        
+        # Create a SlowContractHeartbeat with Created status
+        atn_hb = SlowContractHeartbeat(
+            FromNode=atn.node.name,
+            Contract=contract,
+            Status=ContractStatus.Created,
+            WattHoursUsed=0,
+            MessageCreatedMs=int(time.time() * 1000),
+            MyDigit=5,
+            YourLastDigit=None # First message in chain
+        )
+        
+        atn.contract_handler.latest_hb = atn_hb
+        atn.services.send_threadsafe(
+                Message(
+                    Src=atn.node.name,
+                    Dst=H0N.primary_scada,
+                    Payload=atn.contract_handler.latest_hb,
+                )
+            )
+        
+        
+        print("Atn sent creation hb ... waiting for Scada to transition to Atn")
+        await h.await_for(
+
+            lambda: scada.auto_state == MainAutoState.Atn,
+            "Waiting for auto_state to transition from HomeAlone to Atn",
+        )
+        
+        # Verify state is now Atn
+        assert scada.auto_state == MainAutoState.Atn, f"Expected Atn, got {scada.auto_state}"
+        print("Scada auto_state successfully transitioned from HomeAlone to Atn")
+        
+        # Verify contract handler has the contract
+        assert scada._contract_handler.latest_scada_hb is not None
+        assert scada._contract_handler.latest_scada_hb.Contract.ContractId == contract.ContractId
+        assert scada._contract_handler.latest_scada_hb.Status == ContractStatus.Received
+        
+        # Test that ATN receives heartbeat back from Scada
+        print("Waiting for ATN to receive heartbeat back from Scada")
+        atn_received_counts = h.parent_to_child_stats.num_received_by_type
+
+        await h.await_for(
+            lambda: atn_received_counts['slow.contract.heartbeat'] > 1,
+            "Atn receives slow.contract.heartbeat")
+
+        print(f"Scada auto state is {scada.auto_state}")
+
+        # Verify ATN received the heartbeat
+        print("ATN received heartbeat from Scada")
+        assert atn.contract_handler.latest_hb.FromNode == H0N.primary_scada
+        assert atn.contract_handler.latest_hb.Status == ContractStatus.Received
+        assert atn.contract_handler.latest_hb.FromNode == H0N.primary_scada
+        print(f"ATN contract status: {atn.contract_handler.latest_hb.Status}")
+
+        # hb = SlowContractHeartbeat(
+        #     FromNode=atn.node.name,
+        #     Contract=atn.contract_handler.latest_hb.Contract,
+        #     PreviousStatus=atn.contract_handler.latest_hb.Status,
+        #     Status=ContractStatus.TerminatedByAtn,
+        #     Cause="Atn testing termination",
+        #     MessageCreatedMs=int(time.time() * 1000),
+        #     MyDigit=2,
+        #     YourLastDigit=atn.contract_handler.latest_hb.MyDigit,
+        # )
+        # atn.contract_handler.latest_hb = None
+
+        # atn.services.send_threadsafe(
+        #         Message(
+        #             Src=atn.node.name,
+        #             Dst=H0N.primary_scada,
+        #             Payload=hb,
+        #         )
+        #     )
+        
+        # print("Atn sent termination hb ... waiting for scada to transition to HomeALone")
+        # await h.await_for(
+
+        #     lambda: scada.auto_state == MainAutoState.HomeAlone,
+        #     "Waiting for auto_state to transition from Atn to HomeAlone",
+        # )
+        # That's funny: Ack! Haven't thought through termination by atn
+        


### PR DESCRIPTION
  - fix bug in atomic_ally re how it references the scada's contract handler
  - update power meter to use ScadaAppInterface instead of ScadaApp to avoid circular import