### PR TITLE
Admin layout tightened up

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -4,6 +4,7 @@ on:
   push:
     branches:
        - main
+       - as/admin-dfr
 
 jobs:
   release-gwsproto:

--- a/gw_spaceheat/layout_gen/tst.py
+++ b/gw_spaceheat/layout_gen/tst.py
@@ -23,6 +23,8 @@ from layout_gen import StubConfig
 from layout_gen import HubitatThermostatGenCfg
 from layout_gen import add_thermostat
 from layout_gen import Tank2Cfg
+from layout_gen.dfr import add_dfrs
+from layout_gen.dfr import DfrConf
 from layout_gen.relay import add_relays
 from layout_gen.relay import RelayCfg
 from layout_gen.synth_channels import add_synth
@@ -87,6 +89,16 @@ def make_tst_layout(src_path: Path) -> LayoutDb:
             Strategy="house-parameters-and-weather",
         ),
     )
+
+    add_dfrs(
+        db,
+        DfrConf(
+            DistPumpDefault=20,
+            PrimaryPumpDefault=40,
+            StorePumpDefault=0,
+        ),
+    )
+
 
     return db
 

--- a/packages/gridworks-admin/pyproject.toml
+++ b/packages/gridworks-admin/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "gridworks-admin"
-version = "1.0.0"
+version = "1.0.1"
 description = "CLI tool for monitoring gridworks-scada devices."
 readme = "README.md"
 authors = [

--- a/packages/gridworks-admin/pyproject.toml
+++ b/packages/gridworks-admin/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "gridworks-admin"
-version = "1.0.1"
+version = "1.0.2"
 description = "CLI tool for monitoring gridworks-scada devices."
 readme = "README.md"
 authors = [

--- a/packages/gridworks-admin/pyproject.toml
+++ b/packages/gridworks-admin/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "gridworks-admin"
-version = "1.0.2"
+version = "1.0.3"
 description = "CLI tool for monitoring gridworks-scada devices."
 readme = "README.md"
 authors = [

--- a/packages/gridworks-admin/pyproject.toml
+++ b/packages/gridworks-admin/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "gridworks-admin"
-version = "1.0.4"
+version = "1.0.5"
 description = "CLI tool for monitoring gridworks-scada devices."
 readme = "README.md"
 authors = [

--- a/packages/gridworks-admin/pyproject.toml
+++ b/packages/gridworks-admin/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "gridworks-admin"
-version = "1.0.3"
+version = "1.0.4"
 description = "CLI tool for monitoring gridworks-scada devices."
 readme = "README.md"
 authors = [
@@ -22,6 +22,7 @@ dependencies = [
 
 [project.scripts]
 gwa = "gwadmin:cli.app"
+gridworks-admin = "gwadmin:cli.app"
 
 [build-system]
 requires = ["uv_build>=0.8.8,<0.9.0"]

--- a/packages/gridworks-admin/src/gwadmin/cli.py
+++ b/packages/gridworks-admin/src/gwadmin/cli.py
@@ -80,13 +80,13 @@ def get_admin_config(
             json_data = f.read()
         admin_config = AdminConfig.model_validate_json(json_data)
     if verbose:
-        if verbose == 0:
+        if verbose == 1:
             verbosity = logging.INFO
         else:
             verbosity = logging.DEBUG
         admin_config.verbosity = verbosity
     if paho_verbose:
-        if paho_verbose == 0:
+        if paho_verbose == 1:
             paho_verbosity = logging.INFO
         else:
             paho_verbosity = logging.DEBUG

--- a/packages/gridworks-admin/src/gwadmin/cli.py
+++ b/packages/gridworks-admin/src/gwadmin/cli.py
@@ -67,6 +67,7 @@ def get_admin_config(
     paho_verbose: int = 0,
     show_clock: Optional[bool] = None,
     show_footer: Optional[bool] = None,
+    show_selected_scada_block: Optional[bool] = None,
     default_scada: Optional[str] = None,
     use_last_scada: Optional[bool] = None,
     default_timeout_seconds: Optional[int] = None,
@@ -94,6 +95,8 @@ def get_admin_config(
         admin_config.show_footer = show_footer
     if show_clock is not None:
         admin_config.show_clock = show_clock
+    if show_selected_scada_block is not None:
+        admin_config.show_selected_scada_block = show_selected_scada_block
     if default_scada is not None:
         admin_config.default_scada = default_scada
     if use_last_scada is not None:
@@ -148,6 +151,13 @@ def watch(
             help="Show the footer with shortcut keys."
         ),
     ] = None,
+    show_scada_block: Annotated[
+        Optional[bool],
+        typer.Option(
+            show_default=False,
+            help="Show a colored block for the selected scada in the select section."
+        ),
+    ] = None,
     default_scada: Annotated[
         Optional[str],
         typer.Option(
@@ -189,6 +199,7 @@ def watch(
         paho_verbose=paho_verbose,
         show_clock=show_clock,
         show_footer=show_footer,
+        show_selected_scada_block=show_scada_block,
         default_scada=default_scada,
         use_last_scada=use_last_scada,
         default_timeout_seconds=default_timeout_seconds,
@@ -260,6 +271,13 @@ def config(
             help="Show the footer with shortcut keys."
         ),
     ] = None,
+    show_scada_block: Annotated[
+        Optional[bool],
+        typer.Option(
+            show_default=False,
+            help="Show a colored block for the selected scada in the select section."
+        ),
+    ] = None,
     default_scada: Annotated[
         Optional[str],
         typer.Option(
@@ -301,6 +319,7 @@ def config(
         paho_verbose=paho_verbose,
         show_clock=show_clock,
         show_footer=show_footer,
+        show_selected_scada_block=show_scada_block,
         default_scada=default_scada,
         use_last_scada=use_last_scada,
         default_timeout_seconds=default_timeout_seconds,

--- a/packages/gridworks-admin/src/gwadmin/cli.py
+++ b/packages/gridworks-admin/src/gwadmin/cli.py
@@ -212,9 +212,9 @@ def watch(
         scada = current_config.config.default_scada
     if not scada:
         rich.print(
-            "[yellow][bold]No scada specified[/yellow][/bold] on command line, "
+            "[red][bold]No scada specified[/red][/bold] on command line, "
             "via last-scada-used or in default. "
-            "[yellow][bold]Doing nothing.[/yellow][/bold]"
+            "[red][bold]Doing nothing.[/red][/bold]"
         )
         if not current_config.paths.admin_config_path.exists():
             rich.print(
@@ -227,7 +227,7 @@ def watch(
         raise typer.Exit(2)
     if not scada in current_config.config.scadas:
         rich.print(
-            f"[yellow][bold]Specified scada '{scada}' does not exist[/yellow][/bold] "
+            f"[red][bold]Specified scada '{scada}' does not exist[/red][/bold] "
             f"in config. Available scadas: {available_scadas(current_config.config)}""."
         )
         raise typer.Exit(3)
@@ -344,7 +344,7 @@ def mkconfig(
         typer.Option(
             "--force",
             help="""Overwrites existing configuration file.
-            [yellow][bold]WARNING: [/yellow][/bold]--force will [red][bold]PERMANENTLY DELETE[/red][/bold]
+            [red][bold]WARNING: [/red][/bold]--force will [red][bold]PERMANENTLY DELETE[/red][/bold]
             this Admin configuration.""",
         ),
     ] = False,
@@ -354,13 +354,13 @@ def mkconfig(
     if paths.admin_config_path.exists():
         if not force:
             rich.print(
-                f"Configuartion file {paths.admin_config_path} [yellow][bold]already exists. Doing nothing.[/yellow][/bold]"
+                f"Configuartion file {paths.admin_config_path} [red][bold]already exists. Doing nothing.[/red][/bold]"
             )
             rich.print(f"Use --force to overwrite existing configuration.")
             return
         else:
             rich.print(
-                f"[yellow][bold]DELETING existing configuration[/yellow][/bold]."
+                f"[red][bold]DELETING existing configuration[/red][/bold]."
             )
             paths.admin_config_path.unlink()
     rich.print(f"Creating {paths.admin_config_path}")
@@ -480,7 +480,7 @@ def add_scada(
             scada_config.mqtt.tls.use_tls = use_tls
     else:
         rich.print(
-            f"Scada with name {name} [yellow][bold]already exists. Doing nothing.[/yellow][/bold]\n"
+            f"Scada with name {name} [red][bold]already exists. Doing nothing.[/red][/bold]\n"
         )
         rich.print(
             "Use --update to update the existing configuration or --force to overwrite it.\n"

--- a/packages/gridworks-admin/src/gwadmin/cli.py
+++ b/packages/gridworks-admin/src/gwadmin/cli.py
@@ -308,6 +308,13 @@ def config(
             help="Save any changes to the configuration produced by command line options."
         )
     ] = False,
+    json: Annotated[
+        bool,
+        typer.Option(
+            "--json",
+            help="Generate output in json format."
+        )
+    ] = False,
     config_name: Annotated[
         Optional[str], typer.Option(help=CONFIG_NAME_HELP_TEXT, show_default=False)
     ] = None,
@@ -326,9 +333,13 @@ def config(
         config_name=config_name,
         env_file=env_file,
     )
-    rich.print(current_config.config)
+    if json:
+        print(current_config.model_dump_json(indent=2))
+    else:
+        rich.print(current_config.config)
     if save:
-        rich.print(f"Saving configuration in {current_config.paths.admin_config_path}")
+        if not json:
+            rich.print(f"Saving configuration in {current_config.paths.admin_config_path}")
         current_config.save_config()
 
 
@@ -357,7 +368,7 @@ def mkconfig(
                 f"Configuartion file {paths.admin_config_path} [red][bold]already exists. Doing nothing.[/red][/bold]"
             )
             rich.print(f"Use --force to overwrite existing configuration.")
-            return
+            raise typer.Exit(4)
         else:
             rich.print(
                 f"[red][bold]DELETING existing configuration[/red][/bold]."
@@ -485,7 +496,7 @@ def add_scada(
         rich.print(
             "Use --update to update the existing configuration or --force to overwrite it.\n"
         )
-        return
+        raise typer.Exit(5)
     if len(current_config.config.scadas) == 1 or default:
         current_config.config.default_scada = name
     rich.print(f"Updating config file {current_config.paths.admin_config_path}")

--- a/packages/gridworks-admin/src/gwadmin/cli.py
+++ b/packages/gridworks-admin/src/gwadmin/cli.py
@@ -223,7 +223,6 @@ def watch(
         )
         raise typer.Exit(3)
     current_config.curr_scada = scada
-    rich.print(f"Using scada '{scada}'.")
     if current_config.config.use_last_scada:
         current_config.save_curr_scada(scada)
     if save:
@@ -481,7 +480,7 @@ def add_scada(
 
 def version_callback(value: bool):
     if value:
-        print(f"gws admin {__version__}")
+        rich.print(f"GridWorks Scada Admin Client, version {__version__}")
         raise typer.Exit()
 
 @app.callback()

--- a/packages/gridworks-admin/src/gwadmin/cli.py
+++ b/packages/gridworks-admin/src/gwadmin/cli.py
@@ -137,7 +137,6 @@ def watch(
     show_clock: Annotated[
         Optional[bool],
         typer.Option(
-            "--show-clock",
             show_default=False,
             help="Show the clock in the title bar."
         ),
@@ -145,7 +144,6 @@ def watch(
     show_footer: Annotated[
         Optional[bool],
         typer.Option(
-            "--show-footer",
             show_default=False,
             help="Show the footer with shortcut keys."
         ),
@@ -251,7 +249,6 @@ def config(
     show_clock: Annotated[
         Optional[bool],
         typer.Option(
-            "--show-clock",
             show_default=False,
             help="Show the clock in the title bar."
         ),
@@ -259,7 +256,6 @@ def config(
     show_footer: Annotated[
         Optional[bool],
         typer.Option(
-            "--show-footer",
             show_default=False,
             help="Show the footer with shortcut keys."
         ),

--- a/packages/gridworks-admin/src/gwadmin/config.py
+++ b/packages/gridworks-admin/src/gwadmin/config.py
@@ -33,6 +33,7 @@ class AdminConfig(BaseModel):
     paho_verbosity: Optional[int] = None
     show_clock: bool = False
     show_footer: bool = False
+    show_selected_scada_block: bool = False
     default_timeout_seconds: int = DEFAULT_ADMIN_TIMEOUT
 
 class AdminPaths(Paths):

--- a/packages/gridworks-admin/src/gwadmin/watch/clients/admin_client.py
+++ b/packages/gridworks-admin/src/gwadmin/watch/clients/admin_client.py
@@ -220,7 +220,7 @@ class AdminClient:
             Src=H0N.admin,
             Payload=payload
         )
-        self._logger.debug(f"Publishing {message.mqtt_topic()}")
+        self._logger.debug(f"AdminClient.publish: {message.mqtt_topic()}")
         return self._paho_wrapper.publish(
             message.mqtt_topic(),
             message.model_dump_json(indent=2).encode()

--- a/packages/gridworks-admin/src/gwadmin/watch/relay_app.py
+++ b/packages/gridworks-admin/src/gwadmin/watch/relay_app.py
@@ -89,7 +89,7 @@ class RelaysApp(App):
         yield Header(show_clock=self.settings.config.show_clock)
         yield Horizontal(
             Static(
-                "Select Scada:",
+                "Selected scada:",
                 id="select_scada_label"),
                 Select(
                     (
@@ -99,9 +99,9 @@ class RelaysApp(App):
                             if scada_config.enabled
                         ]
                     ),
-                    prompt="Scada",
                     value=self.settings.curr_scada,
                     id="select_scada",
+                    allow_blank=False,
                 ),
                 MqttState(id="mqtt_state"),
             id="select_scada_container",

--- a/packages/gridworks-admin/src/gwadmin/watch/relay_app.py
+++ b/packages/gridworks-admin/src/gwadmin/watch/relay_app.py
@@ -158,8 +158,11 @@ class RelaysApp(App):
 
     @on(Button.Pressed, "#send_dac_button")
     def send_dac_button(self) -> None:
+        self._logger.info("++send_dac_button")
+        path_dbg = 0
         new_state = self.query_one("#dac_value_input", Input).value
         if new_state is not None:
+            path_dbg |= 0x00000001
             new_state = int(new_state)
             dac_table = self.query_one("#dacs_table", DataTable)
             row = dac_table.get_row_at(dac_table.cursor_row)
@@ -168,12 +171,14 @@ class RelaysApp(App):
                 time_in_minutes = float(time_input_value) if time_input_value else int(self.settings.config.default_timeout_seconds/60)
                 timeout_seconds = int(time_in_minutes * 60)
             except:  # noqa
+                path_dbg |= 0x00000002
                 timeout_seconds = self.settings.config.default_timeout_seconds
             self._dac_client.set_dac(
                 dac_row_name=row[0],
                 new_state=new_state,
                 timeout_seconds=timeout_seconds,
             )
+        self._logger.info(f"--send_dac_button: {new_state}")
 
     def action_toggle_dark(self) -> None:
         self.theme = (

--- a/packages/gridworks-admin/src/gwadmin/watch/relay_app.py
+++ b/packages/gridworks-admin/src/gwadmin/watch/relay_app.py
@@ -86,6 +86,10 @@ class RelaysApp(App):
         return f"{self.settings.curr_scada} - {self.settings.config.scadas[self.settings.curr_scada].long_name}"
 
     def compose(self) -> ComposeResult:
+        if self.settings.config.show_selected_scada_block:
+            selected_scada_block_classes = ""
+        else:
+            selected_scada_block_classes = "undisplayed"
         yield Header(show_clock=self.settings.config.show_clock)
         yield Horizontal(
             Static(
@@ -104,6 +108,11 @@ class RelaysApp(App):
                     allow_blank=False,
                 ),
                 MqttState(id="mqtt_state"),
+                Static(
+                    self.settings.curr_scada,
+                    id="selected_scada_label",
+                    classes=selected_scada_block_classes,
+                ),
             id="select_scada_container",
             classes="section"
         )
@@ -216,6 +225,7 @@ class RelaysApp(App):
             if self.settings.config.use_last_scada:
                 self.settings.save_curr_scada(self.settings.curr_scada)
             self.sub_title = self.format_sub_title()
+            self.query_one("#selected_scada_label", Static).content = self.settings.curr_scada
             self._admin_client.switch_scada()
 
 

--- a/packages/gridworks-admin/src/gwadmin/watch/relay_app.tcss
+++ b/packages/gridworks-admin/src/gwadmin/watch/relay_app.tcss
@@ -29,8 +29,12 @@ Button {
      height: 3;
      margin: 0 0;
      padding: 0 0;
-     text-style: bold;
 }
+
+#select_scada SelectCurrent Static {
+  color: $accent;
+}
+
 
 #mqtt_state {
     margin: 0 4;

--- a/packages/gridworks-admin/src/gwadmin/watch/relay_app.tcss
+++ b/packages/gridworks-admin/src/gwadmin/watch/relay_app.tcss
@@ -35,11 +35,20 @@ Button {
   color: $accent;
 }
 
-
 #mqtt_state {
     margin: 0 4;
     content-align: left middle;
+    width: auto;
 }
+
+#selected_scada_label {
+    margin: 0 5;
+    padding: 1 5;
+    color: $text;
+    background: $success-lighten-3;
+    width: auto;
+}
+
 
 #relays {
     height: 10fr;

--- a/packages/gridworks-admin/src/gwadmin/watch/relay_app.tcss
+++ b/packages/gridworks-admin/src/gwadmin/watch/relay_app.tcss
@@ -2,26 +2,79 @@ Screen {
     layout: vertical;
 }
 
-.container {
+.section {
+    border: solid $border;
+
+}
+
+Button {
+    margin: 1 2;
+    border-title-color: $text;
+}
+
+#select_scada_container {
     height: auto;
-    # width: auto;
     border: solid $border;
 }
 
-.label {
+#select_scada_label {
     height: 3;
     content-align: center middle;
     width: auto;
-}
-
-#dacs_table {
-    width: 60;
-    border: solid $border;
     margin: 0 1;
 }
 
+#select_scada {
+     width: 20;
+     height: 3;
+     margin: 0 0;
+     padding: 0 0;
+     text-style: bold;
+}
+
+#mqtt_state {
+    margin: 0 4;
+    content-align: left middle;
+}
+
+#relays {
+    height: 10fr;
+}
+
+#relays_table {
+    width: 4fr;
+}
+
+#relay_toggle_button_container {
+    layout: horizontal;
+    border: solid $border;
+    align: center middle;
+    padding: 1 1;
+    width: 2.5fr;
+}
+
+#relay_toggle_button {
+    width: 1fr;
+    height: 5;
+    margin: 0 1;
+    padding: 0 0;
+    text-style: bold;
+    text-align: center;
+}
+
+#dacs {
+    height: 4fr;
+}
+#dacs_table {
+    width: 4fr;
+    height: auto;
+    height: 8;
+}
+
 #dac_control_container {
-    width: 60;
+    width: 2.5fr;
+    border: solid $border;
+    height: 8;
 }
 
 #dac_input_vertical {
@@ -30,67 +83,19 @@ Screen {
 }
 
 #dacs_input_label {
-    margin: 0 2;
-    width: 20;
+    margin: 2 1;
+    width: auto;
 }
 
 #dac_value_input {
-    width: 10;
+    width: 1fr;
     align: center middle;
-    margin: 1 3;
+    margin: 1 0;
 }
 
 #send_dac_button {
-    width: 30;
+    width: 1fr;
     align: center middle;
-}
-
-#dacs {
-    height: 4fr;
-    border: solid $border;
-}
-
-Relays {
-    height: 20fr;
-}
-
-#mqtt_state {
-    height: 1fr;
-    border: solid $border;
-}
-
-#relays_table {
-    height: 3fr;
-    border: solid $border;
-}
-
-#relay_toggle_button_container {
-    layout: horizontal;
-    border: solid $border;
-    align: center middle;
-    height: 1fr;
-    padding: 1 1;
-}
-
-Button {
-    margin: 1 2;
-    border-title-color: $text;
-}
-
-RelayToggleButton {
-    width: 40;
-    height: 3;
-    margin: 0 1;
-    padding: 0 0;
-    text-style: bold;
-}
-
-Select {
-     width: 40;
-     height: 3;
-     margin: 0 1;
-     padding: 0 0;
-     text-style: bold;
 }
 
 TimerDigits {
@@ -100,7 +105,7 @@ TimerDigits {
 TimeInput {
     width: 35;
     margin: 1 2;
-    }
+}
 
 .undisplayed {
     display: none;

--- a/packages/gridworks-admin/src/gwadmin/watch/relay_app.tcss
+++ b/packages/gridworks-admin/src/gwadmin/watch/relay_app.tcss
@@ -111,13 +111,20 @@ Button {
     align: center middle;
 }
 
+KeepAliveButton {
+    margin: 0 2;
+}
+
+ReleaseControlButton {
+   margin: 0 2;
+}
 TimerDigits {
-    margin: 1 2;
+    margin: 0 2;
 }
 
 TimeInput {
     width: 35;
-    margin: 1 2;
+    margin: 0 2;
 }
 
 .undisplayed {

--- a/packages/gridworks-admin/src/gwadmin/watch/widgets/mqtt.py
+++ b/packages/gridworks-admin/src/gwadmin/watch/widgets/mqtt.py
@@ -38,12 +38,11 @@ class MqttState(Widget):
 
     def render(self) -> str:
         if self.mqtt_state == ConstrainedMQTTClient.States.active:
-            color = "green"
+            color = "$success"
         else:
-            color = "red"
+            color = "$error"
         return (
             f"MQTT broker connection: [{color}]{self.mqtt_state:12s}[/{color}]"
-
             # Counters disabled as defense against memory leaks:
             # f"  Messages received: {self.message_count}  "
             # f"Snapshots: {self.snapshot_count}  "

--- a/packages/gridworks-admin/src/gwadmin/watch/widgets/mqtt.py
+++ b/packages/gridworks-admin/src/gwadmin/watch/widgets/mqtt.py
@@ -37,8 +37,12 @@ class MqttState(Widget):
     layout_count: Reactive[int] = reactive(0, layout=True)
 
     def render(self) -> str:
+        if self.mqtt_state == ConstrainedMQTTClient.States.active:
+            color = "green"
+        else:
+            color = "red"
         return (
-            f"MQTT broker connection: {self.mqtt_state:12s}"
+            f"MQTT broker connection: [{color}]{self.mqtt_state:12s}[/{color}]"
 
             # Counters disabled as defense against memory leaks:
             # f"  Messages received: {self.message_count}  "

--- a/packages/gridworks-admin/src/gwadmin/watch/widgets/relays.py
+++ b/packages/gridworks-admin/src/gwadmin/watch/widgets/relays.py
@@ -6,15 +6,12 @@ from typing import Optional
 from textual.app import ComposeResult
 from textual.containers import Horizontal
 from textual.containers import HorizontalGroup
-from textual.containers import Vertical
 from textual.logging import TextualHandler
 from textual.messages import Message
 from textual.reactive import Reactive
 from textual.reactive import reactive
 from textual.widget import Widget
 from textual.widgets import DataTable
-from textual.widgets import Select
-from textual.widgets import Static
 from textual.widgets._data_table import CellType  # noqa
 
 from gwadmin.config import DEFAULT_ADMIN_TIMEOUT
@@ -22,15 +19,11 @@ from gwadmin.watch.clients.constrained_mqtt_client import ConstrainedMQTTClient
 from gwadmin.watch.clients.relay_client import ObservedRelayStateChange
 from gwadmin.watch.clients.relay_client import RelayClientCallbacks
 from gwadmin.watch.clients.relay_client import RelayConfigChange
-from gwadmin.watch.widgets.keepalive import KeepAliveButton
-from gwadmin.watch.widgets.keepalive import ReleaseControlButton
 from gwadmin.watch.widgets.mqtt import Mqtt
 from gwadmin.watch.widgets.mqtt import MqttState
 from gwadmin.watch.widgets.relay_toggle_button import RelayToggleButton
 from gwadmin.watch.widgets.relay_widget_info import RelayWidgetConfig
 from gwadmin.watch.widgets.relay_widget_info import RelayWidgetInfo
-from gwadmin.watch.widgets.time_input import TimeInput
-from gwadmin.watch.widgets.timer import TimerDigits
 from gwsproto.named_types import LayoutLite
 from gwsproto.named_types import SnapshotSpaceheat
 
@@ -88,42 +81,28 @@ class Relays(Widget):
         super().__init__(**kwargs)
 
     def compose(self) -> ComposeResult:
-        with Vertical():
-            yield MqttState(id="mqtt_state")
-            yield Horizontal(
-                Static("Select Scada: ", classes="label"),
-                Select(
-                    ((scada, scada) for scada in self._scadas),
-                    prompt="Scada",
-                    value=self._initial_scada,
-                    id="select_scada",
-                ),
-                classes="container",
-            )
-            with HorizontalGroup():
-                yield KeepAliveButton(default_timeout_seconds=self._default_timeout_seconds)
-                yield ReleaseControlButton(default_timeout_seconds=self._default_timeout_seconds)
-                yield TimeInput(default_timeout_seconds=self._default_timeout_seconds)
-                yield TimerDigits(default_timeout_seconds=self._default_timeout_seconds)
-            yield DataTable(
+        h = Horizontal(
+            DataTable(
                 id="relays_table",
                 zebra_stripes=True,
                 cursor_type="row",
-            )
-            with HorizontalGroup(
-                id="relay_toggle_button_container",
-            ):
-                yield RelayToggleButton(
-                    label="bar",
-                    id="relay_toggle_button",
+                classes="subsection"
+            ),
+            HorizontalGroup(
+            RelayToggleButton(
+                label="bar",
+                id="relay_toggle_button",
                 ).data_bind(
                     energized=Relays.curr_energized,
                     config=Relays.curr_config,
-                )
-            # yield DataTable(
-            #     id="message_table",
-            #     classes="undisplayed",
-            # )
+                ),
+                id="relay_toggle_button_container",
+                classes="subsection",
+            ),
+            id="relays_container"
+        )
+        h.border_title = "Relays"
+        yield h
 
     def on_mount(self) -> None:
         data_table = self.query_one("#relays_table", DataTable)
@@ -135,10 +114,6 @@ class Relays(Widget):
             ("Energized", None),
         ]:
             data_table.add_column(column_name, key=column_name, width=width)
-        # message_table = self.query_one("#message_table", DataTable)
-        # message_table.add_columns(
-        # "Time", "Type", "Payload",
-        # )
 
     def _get_relay_row_data(self, relay_name: str) -> dict[str, CellType]:
         if relay_name in self._relays:
@@ -208,53 +183,47 @@ class Relays(Widget):
             "Name",
             key=lambda row: (row[0], row[1]) if row[0] is not None else (sys.maxsize, row[1]),
         )
+        if table.is_valid_coordinate(table.cursor_coordinate):
+            selected_row_key = table.coordinate_to_cell_key(table.cursor_coordinate)[0]
+        else:
+            selected_row_key = ""
+        self._update_buttons(selected_row_key)
         self.logger.info("--on_relays_config_change")
 
     def _update_buttons(self, relay_name: str) -> None:
-        relay_info = self._relays[relay_name]
-        self.curr_energized = relay_info.get_state()
-        self.curr_config = relay_info.config
+        relay_info = self._relays.get(relay_name)
+        if relay_info is not None:
+            curr_energized = relay_info.get_state()
+            curr_config = relay_info.config
+            curr_title = relay_info.config.table_name.border_title
+        else:
+            curr_energized = None
+            curr_config = RelayWidgetConfig()
+            curr_title = ""
+        self.curr_energized = curr_energized
+        self.curr_config = curr_config
         self.query_one(
             "#relay_toggle_button_container",
             HorizontalGroup,
-        ).border_title = relay_info.config.table_name.border_title
+        ).border_title = curr_title
 
     def on_data_table_row_highlighted(self, message: DataTable.RowHighlighted) -> None:
-        self._update_relay_row(message.row_key.value)
-        self._update_buttons(message.row_key.value)
+        self._update_relay_row(message.row_key.value if message.row_key is not None else "")
+        self._update_buttons(message.row_key.value if message.row_key is not None else "")
 
     def on_relays_layout(self, message: Layout) -> None:  # noqa
-        self.query_one(MqttState).message_count += 1
-        self.query_one(MqttState).layout_count += 1
-        # self.query_one("#message_table", DataTable).add_row(
-        #     datetime.datetime.now(),
-        #     type_name(LayoutLite),
-        #     message.layout,
-        # )
-        # self.query_one("#message_table", DataTable).scroll_end()
+        self.app.query_one(MqttState).message_count += 1
+        self.app.query_one(MqttState).layout_count += 1
 
     def on_relays_snapshot(self, message: Snapshot) -> None:  # noqa
-        self.query_one(MqttState).message_count += 1
-        self.query_one(MqttState).snapshot_count += 1
-        # self.query_one("#message_table", DataTable).add_row(
-        #     datetime.datetime.now(),
-        #     type_name(SnapshotSpaceheat),
-        #     message.snapshot,
-        # )
-        # self.query_one("#message_table", DataTable).scroll_end()
-    
+        self.app.query_one(MqttState).message_count += 1
+        self.app.query_one(MqttState).snapshot_count += 1
+
     def on_mqtt_state_change(self, message: Mqtt.StateChange):
-        self.query_one(MqttState).mqtt_state = message.new_state
+        self.app.query_one(MqttState).mqtt_state = message.new_state
 
     def on_mqtt_receipt(self, message: Mqtt.Receipt):  # noqa
-        self.query_one(MqttState).message_count += 1
-        # payload = json.loads(message.payload.decode("utf-8"))
-        # self.query_one("#message_table", DataTable).add_row(
-        #     datetime.datetime.now(),
-        #     MQTTTopic.decode(message.topic).message_type,
-        #     str(payload.get("Payload", payload))
-        # )
-        # self.query_one("#message_table", DataTable).scroll_end()
+        self.app.query_one(MqttState).message_count += 1
 
     def action_toggle_relay(self) -> None:
         self.query_one(

--- a/packages/gridworks-admin/src/gwadmin/watch/widgets/relays.py
+++ b/packages/gridworks-admin/src/gwadmin/watch/widgets/relays.py
@@ -156,6 +156,7 @@ class Relays(Widget):
             )
 
     def on_relays_config_change(self, message: ConfigChange) -> None:
+        self.logger.debug("++on_relays_config_change  changes: %d ", len(message.changes))
         message.prevent_default()
         table = self.query_one("#relays_table", DataTable)
         for relay_name, change in message.changes.items():
@@ -188,9 +189,10 @@ class Relays(Widget):
         else:
             selected_row_key = ""
         self._update_buttons(selected_row_key)
-        self.logger.info("--on_relays_config_change")
+        self.logger.debug("--on_relays_config_change: selected row key: %s", selected_row_key.value if selected_row_key is not "" else "")
 
     def _update_buttons(self, relay_name: str) -> None:
+        self.logger.debug("++Relays._update_buttons: %s", relay_name)
         relay_info = self._relays.get(relay_name)
         if relay_info is not None:
             curr_energized = relay_info.get_state()
@@ -206,6 +208,7 @@ class Relays(Widget):
             "#relay_toggle_button_container",
             HorizontalGroup,
         ).border_title = curr_title
+        self.logger.debug("--Relays._update_buttons: %s  %s", relay_name, curr_title)
 
     def on_data_table_row_highlighted(self, message: DataTable.RowHighlighted) -> None:
         self._update_relay_row(message.row_key.value if message.row_key is not None else "")

--- a/tests/config/hardware-layout.json
+++ b/tests/config/hardware-layout.json
@@ -310,6 +310,39 @@
       "TerminalAssetAlias": "d1.isone.ct.newhaven.orange1.ta",
       "TypeName": "data.channel.gt",
       "Version": "001"
+    },
+    {
+      "AboutNodeName": "dist-010v",
+      "CapturedByNodeName": "dfr-multiplexer",
+      "DisplayName": "Dist 010V",
+      "Id": "3eafa498-0a7a-4222-8e70-2645f01cc215",
+      "Name": "dist-010v",
+      "TelemetryName": "VoltsTimesTen",
+      "TerminalAssetAlias": "d1.isone.ct.newhaven.orange1.ta",
+      "TypeName": "data.channel.gt",
+      "Version": "001"
+    },
+    {
+      "AboutNodeName": "primary-010v",
+      "CapturedByNodeName": "dfr-multiplexer",
+      "DisplayName": "Primary 010V",
+      "Id": "ddca1429-ae7e-4b0d-9a03-99754e4a7d31",
+      "Name": "primary-010v",
+      "TelemetryName": "VoltsTimesTen",
+      "TerminalAssetAlias": "d1.isone.ct.newhaven.orange1.ta",
+      "TypeName": "data.channel.gt",
+      "Version": "001"
+    },
+    {
+      "AboutNodeName": "store-010v",
+      "CapturedByNodeName": "dfr-multiplexer",
+      "DisplayName": "Store 010V",
+      "Id": "566ad060-37d2-4bcb-a9d1-ce0111a03b56",
+      "Name": "store-010v",
+      "TelemetryName": "VoltsTimesTen",
+      "TerminalAssetAlias": "d1.isone.ct.newhaven.orange1.ta",
+      "TypeName": "data.channel.gt",
+      "Version": "001"
     }
   ],
   "ElectricMeterCacs": [
@@ -418,6 +451,13 @@
       "ComponentAttributeClassId": "f88fbf89-5b74-46d6-84a3-8e7494d08435",
       "DisplayName": "GridWorks TankModule2 (Uses 2 picos)",
       "MakeModel": "GRIDWORKS__TANKMODULE2",
+      "TypeName": "component.attribute.class.gt",
+      "Version": "001"
+    },
+    {
+      "ComponentAttributeClassId": "69a0e36e-9c15-4d50-8a7b-ae63649ecc36",
+      "DisplayName": "DFRobot DFR0971 X 2",
+      "MakeModel": "DFROBOT__DFR0971_TIMES2",
       "TypeName": "component.attribute.class.gt",
       "Version": "001"
     }
@@ -813,7 +853,7 @@
     {
       "AsyncCaptureDeltaMicroVolts": 2000,
       "ComponentAttributeClassId": "f88fbf89-5b74-46d6-84a3-8e7494d08435",
-      "ComponentId": "362c9d50-c952-43b4-be2c-95dfd7a25afd",
+      "ComponentId": "8904ace0-2348-4b04-8432-7591038cf9d1",
       "ConfigList": [
         {
           "AsyncCapture": true,
@@ -893,14 +933,59 @@
       "NumSampleAverages": 30,
       "PicoAHwUid": "pico_aaaaaa",
       "PicoBHwUid": "pico_bbbbbb",
-      "PicoKOhms": 30,
       "Samples": 1000,
       "SendMicroVolts": true,
       "SerialNumber": "9999",
-      "TempCalcMethod": "SimpleBetaForPico",
+      "TempCalcMethod": "SimpleBeta",
       "ThermistorBeta": 3977,
       "TypeName": "pico.tank.module.component.gt",
       "Version": "010"
+    },
+    {
+      "ComponentAttributeClassId": "69a0e36e-9c15-4d50-8a7b-ae63649ecc36",
+      "ComponentId": "3b437278-d34a-4c20-be2e-756b06bffc9a",
+      "ConfigList": [
+        {
+          "AsyncCapture": true,
+          "CapturePeriodS": 300,
+          "ChannelName": "dist-010v",
+          "Exponent": 1,
+          "InitialVoltsTimes100": 20,
+          "OutputIdx": 1,
+          "TypeName": "dfr.config",
+          "Unit": "VoltsRms",
+          "Version": "000"
+        },
+        {
+          "AsyncCapture": true,
+          "CapturePeriodS": 300,
+          "ChannelName": "primary-010v",
+          "Exponent": 1,
+          "InitialVoltsTimes100": 40,
+          "OutputIdx": 2,
+          "TypeName": "dfr.config",
+          "Unit": "VoltsRms",
+          "Version": "000"
+        },
+        {
+          "AsyncCapture": true,
+          "CapturePeriodS": 300,
+          "ChannelName": "store-010v",
+          "Exponent": 1,
+          "InitialVoltsTimes100": 0,
+          "OutputIdx": 3,
+          "TypeName": "dfr.config",
+          "Unit": "VoltsRms",
+          "Version": "000"
+        }
+      ],
+      "DisplayName": "DFRobot 010V output X 2",
+      "I2cAddressList": [
+        94,
+        95
+      ],
+      "TypeName": "dfr.component.gt",
+      "Version": "000"
     }
   ],
   "ShNodes": [
@@ -1256,7 +1341,7 @@
     {
       "ActorClass": "ApiTankModule",
       "ActorHierarchyName": "s.buffer",
-      "ComponentId": "362c9d50-c952-43b4-be2c-95dfd7a25afd",
+      "ComponentId": "8904ace0-2348-4b04-8432-7591038cf9d1",
       "DisplayName": "Buffer Tank",
       "Name": "buffer",
       "ShNodeId": "68596845-2e66-4f9d-a876-90da381ddc37",
@@ -1292,6 +1377,46 @@
       "DisplayName": "buffer-depth4",
       "Name": "buffer-depth4",
       "ShNodeId": "cf5a5804-81a7-464d-b70d-590f41401cf2",
+      "TypeName": "spaceheat.node.gt",
+      "Version": "200"
+    },
+    {
+      "ActorClass": "I2cDfrMultiplexer",
+      "ActorHierarchyName": "s.dfr-multiplexer",
+      "ComponentId": "3b437278-d34a-4c20-be2e-756b06bffc9a",
+      "DisplayName": "I2c Zero Ten Out Multiplexer",
+      "Name": "dfr-multiplexer",
+      "ShNodeId": "af931edc-fca9-4aaf-82f0-6632e7e90633",
+      "TypeName": "spaceheat.node.gt",
+      "Version": "200"
+    },
+    {
+      "ActorClass": "ZeroTenOutputer",
+      "ActorHierarchyName": "s.dist-010v",
+      "DisplayName": "Dist DFR",
+      "Handle": "auto.dist-010v",
+      "Name": "dist-010v",
+      "ShNodeId": "f137f4a2-3fb9-423d-ab83-dc2f60525c09",
+      "TypeName": "spaceheat.node.gt",
+      "Version": "200"
+    },
+    {
+      "ActorClass": "ZeroTenOutputer",
+      "ActorHierarchyName": "s.primary-010v",
+      "DisplayName": "Primary DFR",
+      "Handle": "auto.primary-010v",
+      "Name": "primary-010v",
+      "ShNodeId": "30a2b01a-6b00-49bf-8fa1-9450f27289b8",
+      "TypeName": "spaceheat.node.gt",
+      "Version": "200"
+    },
+    {
+      "ActorClass": "ZeroTenOutputer",
+      "ActorHierarchyName": "s.store-010v",
+      "DisplayName": "Store DFR",
+      "Handle": "auto.store-010v",
+      "Name": "store-010v",
+      "ShNodeId": "8e631dc8-2049-4e15-b73c-1b281520595b",
       "TypeName": "spaceheat.node.gt",
       "Version": "200"
     }

--- a/tests/test_misc/test_admin.py
+++ b/tests/test_misc/test_admin.py
@@ -1,14 +1,25 @@
+import os
+import textwrap
 from typing import Any
+from typing import Optional
 
 import pytest
 import rich
 
 from gwproactor.config.mqtt import TLSInfo
+from click.testing import Result as ClickResult
+from pydantic import SecretStr
 from textual.widgets import Button
 from textual.widgets import Input
+from typer.testing import CliRunner
 
+from gwadmin.cli import app as gwa
 from gwadmin.cli import get_admin_config
+from gwadmin.cli import __version__ as gwa_version
+from gwadmin.config import AdminConfig
 from gwadmin.config import AdminMQTTClient
+from gwadmin.config import AdminPaths
+from gwadmin.config import CurrentAdminConfig
 from gwadmin.config import ScadaConfig
 from gwadmin.watch.clients.constrained_mqtt_client import ConstrainedMQTTClient
 from gwadmin.watch.relay_app import RelaysApp
@@ -21,6 +32,10 @@ from textual.widgets import DataTable
 from actors.config import AdminLinkSettings
 from actors.config import ScadaSettings
 from tests.utils.scada_live_test_helper import ScadaLiveTest
+
+
+runner = CliRunner()
+
 
 def assert_relay_table_row(app: RelaysApp, exp_row: list[Any], tag: str = ""):
     table = app.query_one("#relays_table", DataTable)
@@ -39,10 +54,10 @@ def assert_relay_table_row(app: RelaysApp, exp_row: list[Any], tag: str = ""):
     )
     button  = app.query_one("#relay_toggle_button", RelayToggleButton)
     if exp_row[-1] == "⚫️":
-        exp_button_title = f"E[underline]n[/underline]ergize"
+        exp_button_title = "E[underline]n[/underline]ergize"
         exp_label_icon = "🔴"
     else:
-        exp_button_title = f"Dee[underline]n[/underline]ergize"
+        exp_button_title = "Dee[underline]n[/underline]ergize"
         exp_label_icon = "⚫️"
     assert button.border_title == exp_button_title, f"Unexpected toggle button border title {tag_str}"
     assert button.label == f"{exp_label_icon} {exp_row[-2]}", f"Unexpected toggle button label {tag_str}"
@@ -83,6 +98,25 @@ def print_dacs(app: RelaysApp, tag = ""):
     rich.print(f"Dacs table  ({tag})")
     for i in range(len(table.rows)):
         rich.print(f"  {i}: {'[red]*[/red]' if i == table.cursor_row else ' '}  {table.get_row_at(i)}")
+
+def _check_config(exp: AdminConfig, paths: Optional[AdminPaths] = None) -> AdminConfig:
+    if paths is None:
+        paths = AdminPaths(name="admin")
+    with paths.admin_config_path.open("r") as f:
+        file_loaded = AdminConfig.model_validate_json(f.read())
+    command_loaded = CurrentAdminConfig.model_validate_json(
+            _gwa(
+                [
+                    "config",
+                    "--json",
+                    "--config-name",
+                    paths.name
+                ]
+            ).output
+        )
+    assert command_loaded.config.model_dump_json(indent=2) == file_loaded.model_dump_json(indent=2)
+    assert exp.model_dump_json(indent=2) == command_loaded.config.model_dump_json(indent=2)
+    return command_loaded.config
 
 
 @pytest.mark.asyncio
@@ -221,7 +255,7 @@ async def test_admin_dac_set(request: pytest.FixtureRequest) -> None:
             )
             if not success:
                 print_dacs(relays_app, "Scada did not report DAC change")
-                raise AssertionError(f"Timeout waiting for admin to dac update")
+                raise AssertionError("Timeout waiting for admin to dac update")
             # verify change is as expected
             assert_dac_table_row(
                 relays_app,
@@ -230,4 +264,141 @@ async def test_admin_dac_set(request: pytest.FixtureRequest) -> None:
                 tag="dac value set"
             )
 
+def _result_str(result: ClickResult, command: list[str], tag: str = "") -> str:
+    tag_str = "" if not tag else f"\t<{tag}>\n"
+    return (
+        f"{tag_str}"
+        f"exit code: {result.exit_code}\n"
+        f"\t{result!s} from command\n"
+        f"\t<gwa {' '.join([str(entry) for entry in command])}> with output\n"
+        f"{textwrap.indent(result.output, '        ')}"
+    )
 
+def _gwa(command: str | list[str], exp_exit: int = 0, tag: str = "") -> ClickResult:
+    if isinstance(command, str):
+        command = [command]
+    result = runner.invoke(gwa, command, env=os.environ)
+    assert result.exit_code == exp_exit, _result_str(result, command, tag=tag)
+    return result
+
+
+def test_gwa_version() -> None:
+    """Verify 'gwa version' produces expected results."""
+    result = _gwa(["--version"])
+    assert gwa_version in result.output
+
+def test_gwa_config_file() -> None:
+    paths = AdminPaths(name="admin")
+    result = _gwa(["config-file"])
+    exp = str(paths.admin_config_path)
+    got = result.output.strip().replace("\n", "")
+    assert exp == got
+
+def test_gwa_empty_config() -> None:
+    result = _gwa(["config", "--json"])
+    exp = AdminConfig()
+    got = AdminConfig.model_validate_json(result.output)
+    assert exp == got
+
+def test_gwa_mkconfig() -> None:
+    _gwa(["mkconfig"])
+    exp = AdminConfig()
+    with AdminPaths(name="admin").admin_config_path.open("r") as f:
+        got = AdminConfig.model_validate_json(f.read())
+    assert exp == got
+
+def test_gwa_mkconfig_force() -> None:
+    # Create a config
+    _gwa(["mkconfig"])
+    curr_config = CurrentAdminConfig(
+        paths=AdminPaths(name="admin"),
+    )
+    curr_config.config = _check_config(curr_config.config)
+
+    # Change it
+    curr_config.config.verbosity += 1
+    curr_config.save_config()
+    _check_config(curr_config.config)
+
+    # Try to overwrite it
+    result = _gwa(["mkconfig"], 4)
+    assert "Doing nothing" in result.output
+    assert curr_config.config == _check_config(curr_config.config)
+
+    # Force overwrite it
+    _gwa(["mkconfig", "--force"])
+    _check_config(AdminConfig())
+
+
+def test_gwa_config() -> None:
+    # Create a default config
+    _gwa("mkconfig")
+    _check_config(AdminConfig())
+
+    # Increase verbosity and save
+    _gwa(["config", "--save", "-v"])
+
+    # Verify the change
+    _check_config(AdminConfig(verbosity=20))
+
+def test_gwa_add_scada() -> None:
+    # Create a default config
+    _gwa("mkconfig")
+    _check_config(AdminConfig())
+
+    scada_name = "pear"
+    scfg = ScadaConfig(
+        enabled=False,
+        mqtt=AdminMQTTClient(
+            host="foo",
+            port=1,
+            username="bar",
+            password=SecretStr("bla"),
+            tls=TLSInfo(use_tls=True)
+        ),
+        long_name="baz",
+    )
+
+    # Add a scada
+    _gwa([
+        "add-scada",
+        scada_name,
+        "--no-enabled",
+        "--long-name", scfg.long_name,
+        "--host", scfg.mqtt.host,
+        "--port", scfg.mqtt.port,
+        "--username", scfg.mqtt.username,
+        "--password", scfg.mqtt.password.get_secret_value(),
+        "--use-tls",
+    ])
+
+    exp = AdminConfig(default_scada=scada_name, scadas={scada_name: scfg})
+    _check_config(exp)
+
+    # Try to overwrite
+    new_long_name = "BLA.BLA.BLA"
+    _gwa(
+        [
+            "add-scada",
+            scada_name,
+            "--long-name", new_long_name,
+        ],
+        exp_exit=5,
+    )
+
+    # Verify scada config did not change
+    _check_config(exp)
+
+    # Update
+    _gwa(
+        [
+            "add-scada",
+            scada_name,
+            "--long-name", new_long_name,
+            "--update"
+        ],
+    )
+
+    # Verify the change took
+    exp.scadas[scada_name].long_name = new_long_name
+    _check_config(exp)

--- a/tests/test_misc/test_admin.py
+++ b/tests/test_misc/test_admin.py
@@ -1,7 +1,11 @@
 from typing import Any
 
 import pytest
+import rich
+
 from gwproactor.config.mqtt import TLSInfo
+from textual.widgets import Button
+from textual.widgets import Input
 
 from gwadmin.cli import get_admin_config
 from gwadmin.config import AdminMQTTClient
@@ -43,10 +47,47 @@ def assert_relay_table_row(app: RelaysApp, exp_row: list[Any], tag: str = ""):
     assert button.border_title == exp_button_title, f"Unexpected toggle button border title {tag_str}"
     assert button.label == f"{exp_label_icon} {exp_row[-2]}", f"Unexpected toggle button label {tag_str}"
 
+def assert_dac_table_row(
+        app: RelaysApp,
+        exp_row: list[Any],
+        exp_input: int | None = None,
+        tag: str = ""
+):
+    table = app.query_one("#dacs_table", DataTable)
+    exp_row[1] = int(exp_row[1])
+    got_row = table.get_row_at(table.cursor_row)
+    got_row[1] = int(got_row[1])
+    tag_str = "" if not tag else f"<{tag}>"
+    err_str = (
+        f"Unexpected dac row in dacs table. {tag_str}\n"
+        f"  exp: {exp_row}\n"
+        f"  got: {got_row}\n"
+    )
+    assert got_row == exp_row, err_str
+    dac_input = app.query_one("#dac_value_input", Input)
+    if exp_input is None:
+        assert dac_input.value == ""
+    else:
+        assert int(dac_input.value) == int(exp_input)
+    exp_border_title = f"DAC: {exp_row[0]}"
+    box = app.query_one("#dac_control_container", HorizontalGroup)
+    assert box.border_title == exp_border_title, f"Unexpected toggle button border title {tag_str}"
+    exp_button_label = f"Set {exp_row[0]} to {exp_input if exp_input is not None else ''}"
+    button  = app.query_one("#send_dac_button", Button)
+    assert str(button.label) == exp_button_label, f"Unexpected toggle button label {tag_str}"
+    exp_disabled = not(isinstance(exp_input, int) and 0 <= exp_input <= 100)
+    assert button.disabled == exp_disabled, f"Unexpected toggle button disbaled. Got {button.disabled} {tag_str}"
+
+def print_dacs(app: RelaysApp, tag = ""):
+    table = app.query_one("#dacs_table", DataTable)
+    rich.print(f"Dacs table  ({tag})")
+    for i in range(len(table.rows)):
+        rich.print(f"  {i}: {'[red]*[/red]' if i == table.cursor_row else ' '}  {table.get_row_at(i)}")
+
+
 @pytest.mark.asyncio
-async def test_admin_basic(request: pytest.FixtureRequest) -> None:
-    """This test just verifies that clis can execute dry-runs and help without
-    exception. It does not attempt to test content of execution."""
+async def test_admin_relay_set(request: pytest.FixtureRequest) -> None:
+    """Set a relay and verify we see the set take effect."""
     settings = ScadaSettings(admin=AdminLinkSettings(enabled=True))
     layout = House0Layout.load(settings.paths.hardware_layout)
     async with ScadaLiveTest(
@@ -86,13 +127,13 @@ async def test_admin_basic(request: pytest.FixtureRequest) -> None:
 
             # select the relay table and a relay row scada won't change
             # by itself
-            await pilot.click("#relays_table")
+            await pilot.press("r")
             await pilot.press(*(["down"] * 13))
             assert_relay_table_row(
                 relays_app, [18, "Zone1 Main Ops", "RelayOpen", "CloseRelay", "⚫️"]
             )
 
-            # toggle the relay
+            # set the dac the relay
             await pilot.press("n")
             # wait for it to change
             table = relays_app.query_one("#relays_table", DataTable)
@@ -105,4 +146,88 @@ async def test_admin_basic(request: pytest.FixtureRequest) -> None:
                 relays_app,
                 [18, "Zone1 Main Ops", "RelayClosed", "OpenRelay", "🔴"]
             )
+
+
+
+@pytest.mark.asyncio
+async def test_admin_dac_set(request: pytest.FixtureRequest) -> None:
+    """Set a relay and verify we see the set take effect."""
+    settings = ScadaSettings(admin=AdminLinkSettings(enabled=True))
+    layout = House0Layout.load(settings.paths.hardware_layout)
+    async with ScadaLiveTest(
+            request=request,
+            start_child1=True,
+            child_app_settings=settings,
+    ) as h:
+        await h.await_for(
+            h.child_to_parent_link.active_for_send,
+            "ERROR waiting link active_for_send",
+        )
+        curr_admin_config = get_admin_config(
+            env_file="",
+            verbose=0,
+        )
+        curr_admin_config.curr_scada = "local"
+        curr_admin_config.config.scadas["local"] = ScadaConfig(
+            mqtt=AdminMQTTClient(tls=TLSInfo(use_tls=False)),
+            long_name=layout.scada_g_node_alias,
+        )
+        relays_app = RelaysApp(settings=curr_admin_config)
+        async with relays_app.run_test() as pilot:
+            # Wait for admin to connect to scada
+            mqtt_state = relays_app.query_one("#mqtt_state", MqttState)
+            await h.await_for(
+                lambda: mqtt_state.mqtt_state == ConstrainedMQTTClient.States.active,
+                "ERROR wait for admin mqtt state active",
+            )
+            await h.await_for(
+                lambda: relays_app.layout_received(),
+                "ERROR wait for admin to receive a layout",
+            )
+            await h.await_for(
+                lambda: relays_app.snapshot_received(),
+                "ERROR wait for admin to receive a snapshot",
+            )
+
+            # select the dac table
+            await pilot.press("d")
+            assert relays_app.focused.id == "dacs_table"
+            table = relays_app.query_one("#dacs_table", DataTable)
+            assert_dac_table_row(
+                relays_app, ["Dist", 20], tag="dac default row"
+            )
+
+            # select the input box
+            await pilot.press("\t")
+            assert relays_app.focused.id == "dac_value_input"
+            # enter 31
+            await pilot.press("3", "1")
+            assert_dac_table_row(
+                relays_app,["Dist", 20], 31, tag="dac value entered"
+            )
+
+            # set the dac
+            await pilot.press("\t")
+            assert relays_app.focused.id == "send_dac_button"
+            await pilot.press("enter")
+            #await pilot.press("enter")
+
+            table = relays_app.query_one("#dacs_table", DataTable)
+            success = await h.await_for(
+                lambda: int(table.get_row_at(table.cursor_row)[1]) == 31,
+                "ERROR wait for admin to dac update",
+                timeout=10,
+                raise_timeout=False,
+            )
+            if not success:
+                print_dacs(relays_app, "Scada did not report DAC change")
+                raise AssertionError(f"Timeout waiting for admin to dac update")
+            # verify change is as expected
+            assert_dac_table_row(
+                relays_app,
+                ["Dist", "31"],
+                31,
+                tag="dac value set"
+            )
+
 


### PR DESCRIPTION
This PR tightens up the admin layout, colors the name of the selected scada and, optionally, adds a separate visually obvious background colored block with the name of the selected scada. 

To see the new version run: 
```console
uvx gridworks-admin@latest watch 
```

which shows:
<img width="1728" height="1080" alt="Screenshot 2025-09-25 at 2 48 08 PM" src="https://github.com/user-attachments/assets/43168bb5-74b3-4635-8e72-1c0e63a12d58" />

To see new version with selected scada block run:
```console
uvx gridworks-admin@latest watch --show-scada-block
```

which shows:
<img width="1727" height="1084" alt="Screenshot 2025-09-25 at 2 51 38 PM" src="https://github.com/user-attachments/assets/3ee5257f-74eb-4a06-8338-b9854157cc2f" />


To compare to old version run:
```console
uvx --from gridworks-admin==1.0.1 gwa watch
```

To enable (and save) scada block run:
```console
uvx gridworks-admin@latest watch --show-scada-block --save
```

To disable (and save) scada block run:
```console
uvx gridworks-admin@latest watch --no-show-scada-block --save
```

