### PR TITLE
Add optional colored block indicating currently selected scada

### DIFF
--- a/packages/gridworks-admin/pyproject.toml
+++ b/packages/gridworks-admin/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "gridworks-admin"
-version = "1.0.3"
+version = "1.0.4"
 description = "CLI tool for monitoring gridworks-scada devices."
 readme = "README.md"
 authors = [
@@ -22,6 +22,7 @@ dependencies = [
 
 [project.scripts]
 gwa = "gwadmin:cli.app"
+gridworks-admin = "gwadmin:cli.app"
 
 [build-system]
 requires = ["uv_build>=0.8.8,<0.9.0"]

--- a/packages/gridworks-admin/src/gwadmin/cli.py
+++ b/packages/gridworks-admin/src/gwadmin/cli.py
@@ -67,6 +67,7 @@ def get_admin_config(
     paho_verbose: int = 0,
     show_clock: Optional[bool] = None,
     show_footer: Optional[bool] = None,
+    show_selected_scada_block: Optional[bool] = None,
     default_scada: Optional[str] = None,
     use_last_scada: Optional[bool] = None,
     default_timeout_seconds: Optional[int] = None,
@@ -94,6 +95,8 @@ def get_admin_config(
         admin_config.show_footer = show_footer
     if show_clock is not None:
         admin_config.show_clock = show_clock
+    if show_selected_scada_block is not None:
+        admin_config.show_selected_scada_block = show_selected_scada_block
     if default_scada is not None:
         admin_config.default_scada = default_scada
     if use_last_scada is not None:
@@ -148,6 +151,13 @@ def watch(
             help="Show the footer with shortcut keys."
         ),
     ] = None,
+    show_scada_block: Annotated[
+        Optional[bool],
+        typer.Option(
+            show_default=False,
+            help="Show a colored block for the selected scada in the select section."
+        ),
+    ] = None,
     default_scada: Annotated[
         Optional[str],
         typer.Option(
@@ -189,6 +199,7 @@ def watch(
         paho_verbose=paho_verbose,
         show_clock=show_clock,
         show_footer=show_footer,
+        show_selected_scada_block=show_scada_block,
         default_scada=default_scada,
         use_last_scada=use_last_scada,
         default_timeout_seconds=default_timeout_seconds,
@@ -260,6 +271,13 @@ def config(
             help="Show the footer with shortcut keys."
         ),
     ] = None,
+    show_scada_block: Annotated[
+        Optional[bool],
+        typer.Option(
+            show_default=False,
+            help="Show a colored block for the selected scada in the select section."
+        ),
+    ] = None,
     default_scada: Annotated[
         Optional[str],
         typer.Option(
@@ -301,6 +319,7 @@ def config(
         paho_verbose=paho_verbose,
         show_clock=show_clock,
         show_footer=show_footer,
+        show_selected_scada_block=show_scada_block,
         default_scada=default_scada,
         use_last_scada=use_last_scada,
         default_timeout_seconds=default_timeout_seconds,

--- a/packages/gridworks-admin/src/gwadmin/config.py
+++ b/packages/gridworks-admin/src/gwadmin/config.py
@@ -33,6 +33,7 @@ class AdminConfig(BaseModel):
     paho_verbosity: Optional[int] = None
     show_clock: bool = False
     show_footer: bool = False
+    show_selected_scada_block: bool = False
     default_timeout_seconds: int = DEFAULT_ADMIN_TIMEOUT
 
 class AdminPaths(Paths):

--- a/packages/gridworks-admin/src/gwadmin/watch/relay_app.py
+++ b/packages/gridworks-admin/src/gwadmin/watch/relay_app.py
@@ -104,6 +104,7 @@ class RelaysApp(App):
                     allow_blank=False,
                 ),
                 MqttState(id="mqtt_state"),
+                Static(self.settings.curr_scada, id="selected_scada_label"),
             id="select_scada_container",
             classes="section"
         )
@@ -216,6 +217,7 @@ class RelaysApp(App):
             if self.settings.config.use_last_scada:
                 self.settings.save_curr_scada(self.settings.curr_scada)
             self.sub_title = self.format_sub_title()
+            self.query_one("#selected_scada_label", Static).content = self.settings.curr_scada
             self._admin_client.switch_scada()
 
 

--- a/packages/gridworks-admin/src/gwadmin/watch/relay_app.py
+++ b/packages/gridworks-admin/src/gwadmin/watch/relay_app.py
@@ -86,6 +86,10 @@ class RelaysApp(App):
         return f"{self.settings.curr_scada} - {self.settings.config.scadas[self.settings.curr_scada].long_name}"
 
     def compose(self) -> ComposeResult:
+        if self.settings.config.show_selected_scada_block:
+            selected_scada_block_classes = ""
+        else:
+            selected_scada_block_classes = "undisplayed"
         yield Header(show_clock=self.settings.config.show_clock)
         yield Horizontal(
             Static(
@@ -104,7 +108,11 @@ class RelaysApp(App):
                     allow_blank=False,
                 ),
                 MqttState(id="mqtt_state"),
-                Static(self.settings.curr_scada, id="selected_scada_label"),
+                Static(
+                    self.settings.curr_scada,
+                    id="selected_scada_label",
+                    classes=selected_scada_block_classes,
+                ),
             id="select_scada_container",
             classes="section"
         )

--- a/packages/gridworks-admin/src/gwadmin/watch/relay_app.tcss
+++ b/packages/gridworks-admin/src/gwadmin/watch/relay_app.tcss
@@ -21,13 +21,13 @@ Button {
     height: 3;
     content-align: center middle;
     width: auto;
-    margin: 0 1;
+    margin: 1 1;
 }
 
 #select_scada {
      width: 20;
      height: 3;
-     margin: 0 0;
+     margin: 1 0;
      padding: 0 0;
 }
 
@@ -35,11 +35,20 @@ Button {
   color: $accent;
 }
 
-
 #mqtt_state {
     margin: 0 4;
     content-align: left middle;
+    width: auto;
 }
+
+#selected_scada_label {
+    margin: 1 5;
+    padding: 1 5;
+    color: $text;
+    background: $success-lighten-3;
+    width: auto;
+}
+
 
 #relays {
     height: 10fr;

--- a/packages/gridworks-admin/src/gwadmin/watch/relay_app.tcss
+++ b/packages/gridworks-admin/src/gwadmin/watch/relay_app.tcss
@@ -21,13 +21,13 @@ Button {
     height: 3;
     content-align: center middle;
     width: auto;
-    margin: 1 1;
+    margin: 0 1;
 }
 
 #select_scada {
      width: 20;
      height: 3;
-     margin: 1 0;
+     margin: 0 0;
      padding: 0 0;
 }
 
@@ -42,7 +42,7 @@ Button {
 }
 
 #selected_scada_label {
-    margin: 1 5;
+    margin: 0 5;
     padding: 1 5;
     color: $text;
     background: $success-lighten-3;


### PR DESCRIPTION
Optionally displays a visually obvious colored block showing the current selected scada:

<img width="1727" height="1080" alt="Screenshot 2025-09-25 at 2 21 35 PM" src="https://github.com/user-attachments/assets/0e2f8d5f-e062-4609-90a1-b2063f0dac3e" />

Enable (and save):

```console
gwa watch --show-scada-block --save
``` 

Disable (and save):

```console
gwa watch --no-show-scada-block --save
``` 

