### PR TITLE
Fix for #402: import rich.layout.Layout from the correct location

### DIFF
--- a/gw_spaceheat/actors/atn/dashboard/display/displays.py
+++ b/gw_spaceheat/actors/atn/dashboard/display/displays.py
@@ -8,7 +8,7 @@ from rich.console import ConsoleOptions
 from rich.console import RenderResult
 from rich.style import Style
 from rich.text import Text
-from textual.messages import Layout
+from rich.layout import Layout
 
 from actors.atn.dashboard.misc import UpdateSources
 from actors.atn.atn_config import DashboardSettings

--- a/gw_spaceheat/actors/atn/dashboard/display/displays.py
+++ b/gw_spaceheat/actors/atn/dashboard/display/displays.py
@@ -8,7 +8,6 @@ from rich.console import ConsoleOptions
 from rich.console import RenderResult
 from rich.style import Style
 from rich.text import Text
-from rich.layout import Layout
 
 from actors.atn.dashboard.misc import UpdateSources
 from actors.atn.atn_config import DashboardSettings
@@ -26,7 +25,6 @@ class Displays:
     thermostat: ThermostatDisplay
     power: PowerDisplay
     picture: AsciiPicture
-    layout: Layout
 
     def __init__(
             self,
@@ -82,9 +80,6 @@ class Displays:
         self.thermostat.update()
         self.power.update()
         self.picture.update()
-        self.layout = Layout(
-
-        )
         return self
 
     def __rich_console__(self, _console: Console, _options: ConsoleOptions) -> RenderResult:


### PR DESCRIPTION
I accidentally used textual.messages.Layout where I meant to use rich.layout.Layout. Two weeks ago a [textual change](https://github.com/Textualize/textual/commit/51dbf16d4528eda6aa8f938ce4fca8f81eb61087#diff-fe5f3ac4fa8d4963cc76a032f9767e723903f445c65448124b4cc421322ef6d0L54) added an argument to the texutal.messages.Layout constructor. When CI ran after that update, it picked up the new textual version and crashed. 

I removed the Displays.layout object entirely since it wasn't being used in any case. 