### PR TITLE
Update gwsproto from 1.0.1 to 1.1.0, to include gwproto 1.3.3

### DIFF
--- a/packages/gridworks-scada-protocol/pyproject.toml
+++ b/packages/gridworks-scada-protocol/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "gridworks-scada-protocol"
-version = "1.0.1"
+version = "1.1.0"
 description = "Data structures used in messages between gridworks-scada devices, the gridworks ATN and the gridworks-admin monitoring CLI."
 readme = "README.md"
 authors = [
@@ -10,7 +10,7 @@ homepage = "https://github.com/thegridelectric/gridworks-scada/tree/dev/packages
 repository = "https://github.com/thegridelectric/gridworks-scada/tree/dev/packages/gridworks-scada-protocol"
 requires-python = ">=3.11"
 dependencies = [
-    "gridworks-protocol>=1.3.0",
+    "gridworks-protocol>=1.3.3,<2.0.0",
     "transitions>=0.9.3",
 ]
 


### PR DESCRIPTION
gwadmin inherits gwsproto, so we need this update to track the changed layout.lite and gwproto pico.tank.module.component.gt