### PR TITLE
fix existing state machine re Monitor state

### DIFF
--- a/gw_spaceheat/actors/home_alone/home_alone_tou_base.py
+++ b/gw_spaceheat/actors/home_alone/home_alone_tou_base.py
@@ -50,11 +50,13 @@ class HomeAloneTouBase(ScadaActor):
         {"trigger": "TopGoDormant", "source": "Normal", "dest": "Dormant"},
         {"trigger": "TopGoDormant", "source": "UsingBackupOnpeak", "dest": "Dormant"},
         {"trigger": "TopGoDormant", "source": "ScadaBlind", "dest": "Dormant"},
+        {"trigger": "TopGoDormant", "source": "Monitor", "dest": "Dormant"},
         {"trigger": "TopWakeUp", "source": "Dormant", "dest": "Normal"},
         {"trigger": "JustOffpeak", "source": "UsingBackupOnpeak", "dest": "Normal"},
         {"trigger": "MissingData", "source": "Normal", "dest": "ScadaBlind"},
         {"trigger": "DataAvailable", "source": "ScadaBlind", "dest": "Normal"},
         {"trigger": "MonitorOnly", "source": "Normal", "dest": "Monitor"},
+        {"trigger": "MonitorOnly", "source": "Dormant", "dest": "Monitor"},
         {"trigger": "MonitorAndControl", "source": "Monitor", "dest": "Normal"}
     ]
     
@@ -210,6 +212,7 @@ class HomeAloneTouBase(ScadaActor):
             if  self.just_before_onpeak() or self.zone_setpoints=={}:
                 self.get_zone_setpoints()
 
+            # No control of actuators when in Monitor
             if not self.top_state == HomeAloneTopState.Monitor:
                 # update temperatures_available
                 self.get_latest_temperatures()
@@ -512,7 +515,14 @@ class HomeAloneTouBase(ScadaActor):
     def process_wake_up(self, from_node: ShNode, payload: WakeUp) -> None:
         if self.top_state != HomeAloneTopState.Dormant:
             return
-        # TopWakeUp: Dormant -> Normal
+
+        # Monitor-only mode: Dormant -> Monitor
+        if self.settings.monitor_only:
+            self.trigger_top_event(TopStateEvent.MonitorOnly)
+            self.log("Monitor-only: WakeUp transitioned Dormant -> Monitor")
+            return
+
+        # Normal behavior: Dormant -> Normal
         self.trigger_top_event(TopStateEvent.TopWakeUp)
         self.set_command_tree(boss_node=self.normal_node)
         # let normal node know its waking up


### PR DESCRIPTION
The hierarchical state machine structure is enforced in two ways. The first is through the general rule that nodes only accept commands from their immediate boss and there is a `Command Tree` set up via the ShNode handles.  The second is through creating state machines for nodes, and maintaining this axiom:

a node's state machine is Dormant **if and only if** it has no reports (i.e. not anybody's boss).

This axiom was violated by our `homealone` top state.  The top state would be set to `Monitor` on initialization, but there was no transition for leaving `Monitor`. So if admin took over, the HomeAlone node `h` would no longer be the top of the command tree but it would still be in state `Monitor` instead of state `Dormant`.

This PR fixes that issue by adding two transitions and then making sure that when home alone gets a `WakeUp` message it will trigger `MonitorOnly` if the `.env` setting asks for that.