### PR TITLE
PR for merging dist pump doc to main

### DIFF
--- a/gw_spaceheat/actors/home_alone/home_alone_tou_base.py
+++ b/gw_spaceheat/actors/home_alone/home_alone_tou_base.py
@@ -365,8 +365,7 @@ class HomeAloneTouBase(ScadaActor):
 
     def trigger_zones_at_setpoint_offpeak(self):
         """
-        Called to change top state from UsingNonElectricBackup to Normal, 
-        when backup was started offpeak
+        Called to change top state from UsingNonElectricBackup to Normal
         """
         if self.top_state != LocalControlTopState.UsingNonElectricBackup:
             raise Exception("Should only call trigger_zones_at_setpoint_offpeak in transition from UsingNonElectricBackup to Normal!")


### PR DESCRIPTION
We are stress testing this code at elm with its extremely sick pump, and this gets rid of the risk of houses going cold if the dist pump fails when the Internet is down.

I am going to put this on elm tonight. We need to replicate this functionality over in `ll/aa` (Leaf Leutenant/AtomicAlly), where the comment about not messing with transactive actuators outside of the state machine is critical.

I think this is a fine way to do all the pumps instead of adjusting the state machines. As long as it doesn't have bugs.  Here are notes from the first / major commit. 

I would like a review of this PR from both Thomas and Joe even if we merge and deploy it first.

Bound and harden distribution pump recovery; clarify naming and escalation
This change refines distribution pump recovery behavior and naming, with
explicit guarantees around control release, retry bounds, and escalation.

Behavioral changes:

- Improve observability and escalation semantics:
  - Reset the recovery attempt counter once normal flow resumes (otherwise an
    admin fix, like I did tonight, will leave the code still unable to try
    running pump doctor)
  - Emit a WARNING Glitch when the dist pump doctor procedure begins
    (recorded but non-alarming)
  - Emit a CRITICAL Glitch exactly once when max recovery attempts are exceeded

- Enforce actuator safety invariants:
  - Thermostat/zone relay control and 0-10 defaults always restored in a finally block
    (for example when I went to admin tonight the thermostat relays were all
    energized)

- Rename recovery logic for clarity and scope:
  - pump_doctor → dist_pump_doctor
  - pump_doctor_* → dist_pump_doctor_* variants
  - Variables now reflect the distribution pump specifically

- Introduce explicit constants governing distribution pump recovery:
  - MAX_PUMP_DOCTOR_ATTEMPTS
  - ZONE_CONTROL_DELAY_SECONDS
  - DIST_FLOW_ON_THRESHOLD_GPM_X100

- Refine zone-controller startup gating for dist pump recovery:
  - Rename and clarify startup-delay tracking to reflect zone controller behavior
  - Shorten delay window to match expected valve-open / end-switch timing
  - Improve logs