### PR TITLE
Debug failed transition to BufferOnly

### DIFF
--- a/gw_spaceheat/actors/contract_handler.py
+++ b/gw_spaceheat/actors/contract_handler.py
@@ -189,6 +189,7 @@ class ContractHandler:
             return
         if self.latest_scada_hb.Status not in self.DONE_STATES:
             return
+        self.prev = self.latest_scada_hb
         self.latest_scada_hb = None
         self.energy_used_wh = 0
         self.energy_updated_s = None
@@ -295,13 +296,16 @@ class ContractHandler:
             raise ValueError(f"Unexpected status from ltn_hb: {ltn_hb.Status}")
 
     def scada_terminates_contract_hb(self, cause: str = "") -> SlowContractHeartbeat:
-        """Creats a heartbeat declaring scada termination of contract
-        - can only call if self.latest_scada_hb exists
-        - sets prev to terminating_hb  and latest_scada_hb to None
+        """Creates a heartbeat declaring scada termination of contract
+
+        - Can only call if self.latest_scada_hb exists
+        - Returns the terminating heartbeat
+        - Caller is responsible for persisting and flushing if desired
         """
         if not self.latest_scada_hb:
             raise Exception("Cannot call scada terminates contract if no latest_scada_hb")
-        hb = SlowContractHeartbeat(
+
+        return SlowContractHeartbeat(
             FromNode=self.node.Name,
             Contract=self.latest_scada_hb.Contract,
             PreviousStatus=self.latest_scada_hb.Status,
@@ -312,25 +316,26 @@ class ContractHandler:
             MyDigit=random.choice(range(10)),
             YourLastDigit=self.latest_scada_hb.MyDigit,
         )
-        self.prev = hb
-        self.latest_scada_hb = None
-        return hb
 
     def scada_contract_completion_hb(self, cause="") -> SlowContractHeartbeat:
-        """Creats a heartbeat noting time has passed completion
-        - can only call if self.latest_scada_hb exists
-        - sets prev to this hb and latest_scada_hb to None
+        """Creates a heartbeat noting contract completion by passage of time.
 
-        Raises exception if called before the ContractEndS
+        - Can only call if self.latest_scada_hb exists
+        - Raises exception if called before ContractEndS
+        - Returns completion heartbeat
+        - Caller is responsible for persisting and flushing if desired
         """
         now = time.time()
+    
         if not self.latest_scada_hb:
             raise Exception("Cannot call scada terminates contract if no latest_ltn_hb")
+
         if now < self.latest_scada_hb.Contract.contract_end_s():
             raise Exception(
                 f"scada_detects_contract_complete_hb called at {int(now)}, before ContractEndTime of {self.latest_scada_hb.Contract.contract_end_s()}"
             )
-        hb = SlowContractHeartbeat(
+
+        return SlowContractHeartbeat(
             FromNode=self.node.Name,
             Contract=self.latest_scada_hb.Contract,
             PreviousStatus=self.latest_scada_hb.Status,
@@ -342,9 +347,6 @@ class ContractHandler:
             YourLastDigit=self.latest_scada_hb.MyDigit,
             IsAuthoritative=False # not claiming authority on outcome
         )
-        self.prev = hb
-        self.latest_scada_hb = None
-        return hb
 
     def formatted_contract(self, hb_to_format: Optional[SlowContractHeartbeat] = None) -> str:
         """Format contract heartbeat information for logging in a human-readable format."""

--- a/gw_spaceheat/actors/leaf_ally/all_tanks.py
+++ b/gw_spaceheat/actors/leaf_ally/all_tanks.py
@@ -410,18 +410,17 @@ class AllTanksLeafAlly(ShNodeActor):
             if self.store_pump_monitor.needs_recovery():
                 await self.store_pump_doctor.run()
 
-            # Breach ongoing LTN contract if a zone is below setpoint
-            if self.contract_hb is not None:
-                self.get_zone_setpoints()
-                if self.is_system_cold():
-                    self.log("System is cold - breaching contract")
-                    self._send_to(
-                        self.primary_scada,
-                        AllyGivesUp(Reason="System is cold"),
-                    )
-                    self.send_info("System is cold - breaching contract")
-                    await asyncio.sleep(self.MAIN_LOOP_SLEEP_SECONDS)
-                    continue
+           # Go Dormant if cold
+            self.get_zone_setpoints()
+            if self.is_system_cold():
+                self.log("System is cold - breaching contract")
+                self._send_to(
+                    self.primary_scada,
+                    AllyGivesUp(Reason="System is cold"),
+                )
+                self.send_info("System is cold - breaching contract")
+                await asyncio.sleep(self.MAIN_LOOP_SLEEP_SECONDS)
+                continue
 
             self.engage_brain()
             await asyncio.sleep(self.MAIN_LOOP_SLEEP_SECONDS)

--- a/gw_spaceheat/actors/leaf_ally/all_tanks.py
+++ b/gw_spaceheat/actors/leaf_ally/all_tanks.py
@@ -412,8 +412,8 @@ class AllTanksLeafAlly(ShNodeActor):
 
            # Go Dormant if cold
             self.get_zone_setpoints()
-            if self.is_system_cold():
-                self.log("System is cold - breaching contract")
+            if self.is_system_cold() and self.is_buffer_empty() and self.is_storage_empty():
+                self.log("System is cold, buffer and storage are empty - breaching contract")
                 self._send_to(
                     self.primary_scada,
                     AllyGivesUp(Reason="System is cold"),

--- a/gw_spaceheat/actors/leaf_ally/all_tanks.py
+++ b/gw_spaceheat/actors/leaf_ally/all_tanks.py
@@ -414,11 +414,12 @@ class AllTanksLeafAlly(ShNodeActor):
             if self.contract_hb is not None:
                 self.get_zone_setpoints()
                 if self.is_system_cold():
-                    self.log("Zone(s) below setpoint - breaching contract")
+                    self.log("System is cold - breaching contract")
                     self._send_to(
                         self.primary_scada,
-                        AllyGivesUp(Reason="Zone(s) below setpoint"),
+                        AllyGivesUp(Reason="System is cold"),
                     )
+                    self.send_info("System is cold - breaching contract")
                     await asyncio.sleep(self.MAIN_LOOP_SLEEP_SECONDS)
                     continue
 

--- a/gw_spaceheat/actors/leaf_ally/buffer_only.py
+++ b/gw_spaceheat/actors/leaf_ally/buffer_only.py
@@ -319,8 +319,8 @@ class BufferOnlyLeafAlly(ShNodeActor):
 
             # Go Dormant if cold
             self.get_zone_setpoints()
-            if self.is_system_cold():
-                self.log("System is cold - breaching contract")
+            if self.is_system_cold() and self.is_buffer_empty():
+                self.log("System is cold, buffer is empty - breaching contract")
                 self._send_to(
                     self.primary_scada,
                     AllyGivesUp(Reason="System is cold"),

--- a/gw_spaceheat/actors/leaf_ally/buffer_only.py
+++ b/gw_spaceheat/actors/leaf_ally/buffer_only.py
@@ -321,11 +321,12 @@ class BufferOnlyLeafAlly(ShNodeActor):
             if self.contract_hb is not None:
                 self.get_zone_setpoints()
                 if self.is_system_cold():
-                    self.log("Zone(s) below setpoint - breaching contract")
+                    self.log("System is cold - breaching contract")
                     self._send_to(
                         self.primary_scada,
-                        AllyGivesUp(Reason="Zone(s) below setpoint"),
+                        AllyGivesUp(Reason="System is cold"),
                     )
+                    self.send_info("System is cold - breaching contract")
                     await asyncio.sleep(self.MAIN_LOOP_SLEEP_SECONDS)
                     continue
 

--- a/gw_spaceheat/actors/leaf_ally/buffer_only.py
+++ b/gw_spaceheat/actors/leaf_ally/buffer_only.py
@@ -317,18 +317,17 @@ class BufferOnlyLeafAlly(ShNodeActor):
             if self.store_pump_monitor.needs_recovery():
                 await self.store_pump_doctor.run()
 
-            # Breach ongoing LTN contract if a zone is below setpoint
-            if self.contract_hb is not None:
-                self.get_zone_setpoints()
-                if self.is_system_cold():
-                    self.log("System is cold - breaching contract")
-                    self._send_to(
-                        self.primary_scada,
-                        AllyGivesUp(Reason="System is cold"),
-                    )
-                    self.send_info("System is cold - breaching contract")
-                    await asyncio.sleep(self.MAIN_LOOP_SLEEP_SECONDS)
-                    continue
+            # Go Dormant if cold
+            self.get_zone_setpoints()
+            if self.is_system_cold():
+                self.log("System is cold - breaching contract")
+                self._send_to(
+                    self.primary_scada,
+                    AllyGivesUp(Reason="System is cold"),
+                )
+                self.send_info("System is cold - breaching contract")
+                await asyncio.sleep(self.MAIN_LOOP_SLEEP_SECONDS)
+                continue
 
             self.engage_brain()
             await asyncio.sleep(self.MAIN_LOOP_SLEEP_SECONDS)

--- a/gw_spaceheat/actors/ltn/ltn.py
+++ b/gw_spaceheat/actors/ltn/ltn.py
@@ -883,18 +883,19 @@ class Ltn(PrimeActor):
         flo_git_commit = _get_flo_git_commit()
         self.log(f"Flo git commit: {flo_git_commit}")
 
+        num_tanks = self.total_store_tanks if self.seasonal_storage_mode == SeasonalStorageMode.AllTanks else 1
+
         self.flo_params = FloParamsHouse0(
             GNodeAlias=self.layout.scada_g_node_alias,
             StartUnixS=dijkstra_start_time,
             HorizonHours=self.flo_horizon_hours,
-            NumLayers=int(3*self.total_store_tanks*3), # 3 sensors per tank, 3 layers per sensor
+            NumLayers=int(3*num_tanks*3), # 3 sensors per tank, 3 layers per sensor
             InitialTopTempF=int(t),
             InitialMiddleTempF=int(m),
             InitialBottomTempF=int(b),
             InitialThermocline1= int(th1*3),
             InitialThermocline2= int(th2*3),
-            StorageVolumeGallons = TANK_GALLONS if self.seasonal_storage_mode == SeasonalStorageMode.BufferOnly else self.total_store_tanks * TANK_GALLONS,
-            # TODO: price and weather forecasts should include the current hour if we are running a partial hour
+            StorageVolumeGallons = TANK_GALLONS*num_tanks,
             LmpForecast=self.price_forecast.lmp_usd_per_mwh,
             DistPriceForecast=self.price_forecast.dp_usd_per_mwh,
             RegPriceForecast=self.price_forecast.reg_usd_per_mwh,

--- a/gw_spaceheat/actors/ltn/ltn.py
+++ b/gw_spaceheat/actors/ltn/ltn.py
@@ -157,6 +157,7 @@ class BidRunner(threading.Thread):
                 flo_params_bytes = self.orig_flo_params.model_dump_json().encode('utf-8')
                 try:
                     g = Flo(flo_params_bytes, patting_watchdog=self.pat_watchdog)
+                    self.logger.info(f"Created DGraph with supergraph_meta_path: {g.supergraph_meta_path} and graph file {self.graph_file}")
                 except Exception as e:
                     self.logger.error(f"Error creating DGraph with advanced FLO: {e}")
                     glitch = Glitch(
@@ -887,6 +888,7 @@ class Ltn(PrimeActor):
             GNodeAlias=self.layout.scada_g_node_alias,
             StartUnixS=dijkstra_start_time,
             HorizonHours=self.flo_horizon_hours,
+            NumLayers=int(3*self.total_store_tanks*3), # 3 sensors per tank, 3 layers per sensor
             InitialTopTempF=int(t),
             InitialMiddleTempF=int(m),
             InitialBottomTempF=int(b),
@@ -920,6 +922,7 @@ class Ltn(PrimeActor):
             PreviousEstimateStorageKwhNow=previous_estimate_storage_kwh_now,
             FloGitCommit=flo_git_commit,
         )
+        self.log(f"Flo params: {self.flo_params}") # TODO remove this
         self.services.publish_message(
             self.SCADA_MQTT, 
             Message(Src=self.publication_name, Dst="broadcast", Payload=self.flo_params)
@@ -1222,8 +1225,8 @@ class Ltn(PrimeActor):
             top_temp = round(tank_temps[H0CN.buffer.depth1],1)
             middle_temp = round(tank_temps[H0CN.buffer.depth2],1)
             bottom_temp = round(tank_temps[H0CN.buffer.depth3],1)
-            thermocline1 = 4 #out of 12 layers
-            thermocline2 = 8 #out of 12 layers
+            thermocline1 = 1
+            thermocline2 = 2
             return top_temp, middle_temp, bottom_temp, thermocline1, thermocline2
 
         # Process layer temperatures
@@ -1284,7 +1287,7 @@ class Ltn(PrimeActor):
             top_temp = round(sum(cluster_top)/len(cluster_top))
             middle_temp = round(sum(cluster_middle)/len(cluster_middle))
             bottom_temp = round(sum(cluster_bottom)/len(cluster_bottom))
-            self.log(f"Storage model: {top_temp}({thermocline1}){middle_temp}({thermocline2}){bottom_temp}")
+            self.log(f"Storage model: {top_temp}({thermocline1}){middle_temp}({thermocline2}){bottom_temp} ({len(layer_temps)} layers)")
             return top_temp, middle_temp, bottom_temp, thermocline1, thermocline2
 
         # Dealing with less than 3 clusters
@@ -1300,14 +1303,14 @@ class Ltn(PrimeActor):
                 thermocline1 = len(cluster_top)
                 top_temp = round(sum(cluster_top)/len(cluster_top))
                 bottom_temp = round(sum(cluster_bottom)/len(cluster_bottom))
-                self.log(f"Storage model: {top_temp}({thermocline1}){bottom_temp}")
+                self.log(f"Storage model: {top_temp}({thermocline1}){bottom_temp} ({len(layer_temps)} layers)")
                 return top_temp, top_temp, bottom_temp, thermocline1, thermocline1
             # Single cluster
             else:
                 cluster_top = max(cluster_0, cluster_1, cluster_2, key=lambda x: len(x))
                 top_temp = round(sum(cluster_top)/len(cluster_top))
-                thermocline1 = 12
-                self.log(f"Storage model: {top_temp}({thermocline1})")
+                thermocline1 = len(layer_temps)
+                self.log(f"Storage model: {top_temp}({thermocline1}) ({len(layer_temps)} layers)")
                 return top_temp, top_temp, top_temp, thermocline1, thermocline1
     
     async def get_buffer_available_kwh(self):

--- a/gw_spaceheat/actors/ltn/ltn.py
+++ b/gw_spaceheat/actors/ltn/ltn.py
@@ -157,7 +157,6 @@ class BidRunner(threading.Thread):
                 flo_params_bytes = self.orig_flo_params.model_dump_json().encode('utf-8')
                 try:
                     g = Flo(flo_params_bytes, patting_watchdog=self.pat_watchdog)
-                    self.logger.info(f"Created DGraph with supergraph_meta_path: {g.supergraph_meta_path} and graph file {self.graph_file}")
                 except Exception as e:
                     self.logger.error(f"Error creating DGraph with advanced FLO: {e}")
                     glitch = Glitch(
@@ -922,7 +921,6 @@ class Ltn(PrimeActor):
             PreviousEstimateStorageKwhNow=previous_estimate_storage_kwh_now,
             FloGitCommit=flo_git_commit,
         )
-        self.log(f"Flo params: {self.flo_params}") # TODO remove this
         self.services.publish_message(
             self.SCADA_MQTT, 
             Message(Src=self.publication_name, Dst="broadcast", Payload=self.flo_params)

--- a/gw_spaceheat/actors/scada.py
+++ b/gw_spaceheat/actors/scada.py
@@ -500,6 +500,11 @@ class Scada(PrimeActor, ScadaInterface):
         self.log(f"LeafAlly giving up: {payload.Reason}")
         self.log("Sending termination hb to Scada. State: LeafTransactiveNode -> LocalControl")
         hb = self.contract_handler.scada_terminates_contract_hb(cause=f"Ally Gives up: {payload.Reason}")
+        
+        self.contract_handler.latest_scada_hb = hb
+        self.contract_handler.store_heartbeat()
+        self.contract_handler.flush_latest_scada_hb()
+    
         self._send_to(self.ltn, hb)
         # Cancel any existing warning task
         if hasattr(self, 'contract_task'):
@@ -1011,10 +1016,17 @@ class Scada(PrimeActor, ScadaInterface):
                 elif self.auto_state == MainAutoState.LeafTransactiveNode:
                     self._send_to(self.leaf_ally, self.contract_handler.latest_scada_hb.Contract)
             elif self.contract_handler.active_contract_has_expired(): # wrap up existing
-                self._send_to(self.ltn,
-                    self.contract_handler.scada_contract_completion_hb("Wrapping up existing contract")
+                completion_hb = self.contract_handler.scada_contract_completion_hb(
+                    "Wrapping up existing contract"
                 )
+
+                self.contract_handler.latest_scada_hb = completion_hb
+                self.contract_handler.store_heartbeat()
+                self.contract_handler.flush_latest_scada_hb()
+                self._send_to(self.ltn, completion_hb)
+
                 self.contract_handler.start_new_contract_hb(ltn_hb)
+
                 self._send_to(self.leaf_ally, self.contract_handler.latest_scada_hb.Contract)
                 # will send hb in process_suit_up, after leaf ally acknowledges
         elif ltn_hb.Status == SlowDispatchContractStatus.TerminatedByLtn:
@@ -1050,17 +1062,24 @@ class Scada(PrimeActor, ScadaInterface):
         )
 
     def in_grace_period(self) -> bool:
-        """Scada is NOT dormant, and a contract is active or was active within 5 minutes
-        Effect: if contract_handler.active_contract_has_expired, send a final
-        completion heartbeat, None -> latest_scada_hb -> prev
-        """
+        """Scada is not dormant, and a contract is active or was active within grace period."""
         if self.contract_handler.active_contract_has_expired():
-                self._send_to(self.ltn,
-                        self.contract_handler.scada_contract_completion_hb("Active contract has expired"))
-        if self.contract_handler.latest_scada_hb: # will not be expired
+            completion_hb = self.contract_handler.scada_contract_completion_hb(
+                "Active contract has expired"
+            )
+
+            self.contract_handler.latest_scada_hb = completion_hb
+            self.contract_handler.store_heartbeat()
+            self.contract_handler.flush_latest_scada_hb()
+
+            self._send_to(self.ltn, completion_hb)
+
+        elif self.contract_handler.latest_scada_hb:
             return True
-        elif not self.contract_handler.prev:
+        
+        if not self.contract_handler.prev:
             return False
+
         elif time.time() > self.contract_handler.prev.grace_period_end_s():
             return False
         else:
@@ -1102,6 +1121,11 @@ class Scada(PrimeActor, ScadaInterface):
 
         # Send completion heartbeat and set contract_handler.latest_scada_hb to None
         completion_hb = self.contract_handler.scada_contract_completion_hb("Noticed active contract complete")
+
+        self.contract_handler.latest_scada_hb = completion_hb
+        self.contract_handler.store_heartbeat()
+        self.contract_handler.flush_latest_scada_hb()
+        
         self._send_to(self.ltn, completion_hb)
 
         # Set backup timer for grace period

--- a/gw_spaceheat/actors/scada.py
+++ b/gw_spaceheat/actors/scada.py
@@ -1085,13 +1085,25 @@ class Scada(PrimeActor, ScadaInterface):
 
         grace_end_s = int(actual_end_s+ self.contract_handler.GRACE_PERIOD_MINUTES* 60)
         # Case 1: latest_scada_hb is None - old contract was properly expired
-        # Still send warning since we haven't received a new contract
+        # Still send warning since we haven't received a new contract, then
+        # keep ownership of the grace-period handoff.
         if not self.contract_handler.latest_scada_hb:
             self._send_to(self.ltn, NoNewContractWarning(
                 FromGNodeAlias=self.layout.scada_g_node_alias,
                 ContractId=hb.Contract.ContractId,
                 GraceEndTimeS=grace_end_s
             ))
+            await asyncio.sleep(max(0, grace_end_s - time.time()))
+            if (
+                self.auto_state == MainAutoState.LeafTransactiveNode
+                and self.contract_handler.latest_scada_hb is None
+                and not self.in_grace_period()
+            ):
+                self.log(
+                    f"Grace period expired for contract {hb.Contract.ContractId} "
+                    "- transitioning to LocalControl"
+                )
+                self.auto_trigger(MainAutoEvent.ContractGracePeriodEnds)
             return
          # Case 2: We have a different contract after the wait - this is the normal
          # case where the old contract expired and Ltn sent a new one
@@ -1228,12 +1240,14 @@ class Scada(PrimeActor, ScadaInterface):
 
         ally_state = la.state
         local_control_state = lc.top_state
-
-        if not self.settings.seasonal_storage_mode == SeasonalStorageMode.AllTanks:
-            return # TODO figure out a graceful way to do this for BufferOnly as well
+        dormant_state = (
+            LeafAllyAllTanksState.Dormant 
+            if self.settings.seasonal_storage_mode == SeasonalStorageMode.AllTanks 
+            else LeafAllyBufferOnlyState.Dormant
+        )
 
         if self.auto_state == MainAutoState.Dormant:
-            if ally_state != LeafAllyAllTanksState.Dormant:
+            if ally_state != dormant_state:
                 self.log(f"Noticed auto_state Dormant but LeafAlly in {ally_state}! Sending GoDormant")
                 self._send_to(self.leaf_ally, GoDormant(ToName=self.leaf_ally.name))
             if local_control_state != LocalControlTopState.Dormant:
@@ -1244,7 +1258,7 @@ class Scada(PrimeActor, ScadaInterface):
                 self.log("Noticed auto_state Ltn but no longer in grace period!")
                 self.auto_trigger(MainAutoEvent.ContractGracePeriodEnds)
                 return 
-            if ally_state == LeafAllyAllTanksState.Dormant:
+            if ally_state == dormant_state:
                 self.log("Noticed auto_state Ltn but LeafAlly Dormant!")
                 if self.contract_handler.latest_scada_hb:
                     contract = self.contract_handler.latest_scada_hb.Contract
@@ -1255,7 +1269,7 @@ class Scada(PrimeActor, ScadaInterface):
                 self.log(f"Noticed auto_state Ltn but LocalControl in {local_control_state}! Sending GoDormant")
                 self._send_to(self.local_control, GoDormant(ToName=self.local_control.name))
         elif self.auto_state == MainAutoState.LocalControl:
-            if ally_state != LeafAllyAllTanksState.Dormant:
+            if ally_state != dormant_state:
                 self.log(f"Noticed auto_state LocalControl but LeafAlly in {ally_state}! Sending GoDormant")
                 self._send_to(self.leaf_ally, GoDormant(ToName=self.leaf_ally.name))
             if local_control_state == LocalControlTopState.Dormant:

--- a/gw_spaceheat/actors/scada.py
+++ b/gw_spaceheat/actors/scada.py
@@ -1085,25 +1085,13 @@ class Scada(PrimeActor, ScadaInterface):
 
         grace_end_s = int(actual_end_s+ self.contract_handler.GRACE_PERIOD_MINUTES* 60)
         # Case 1: latest_scada_hb is None - old contract was properly expired
-        # Still send warning since we haven't received a new contract, then
-        # keep ownership of the grace-period handoff.
+        # Still send warning since we haven't received a new contract
         if not self.contract_handler.latest_scada_hb:
             self._send_to(self.ltn, NoNewContractWarning(
                 FromGNodeAlias=self.layout.scada_g_node_alias,
                 ContractId=hb.Contract.ContractId,
                 GraceEndTimeS=grace_end_s
             ))
-            await asyncio.sleep(max(0, grace_end_s - time.time()))
-            if (
-                self.auto_state == MainAutoState.LeafTransactiveNode
-                and self.contract_handler.latest_scada_hb is None
-                and not self.in_grace_period()
-            ):
-                self.log(
-                    f"Grace period expired for contract {hb.Contract.ContractId} "
-                    "- transitioning to LocalControl"
-                )
-                self.auto_trigger(MainAutoEvent.ContractGracePeriodEnds)
             return
          # Case 2: We have a different contract after the wait - this is the normal
          # case where the old contract expired and Ltn sent a new one

--- a/gw_spaceheat/actors/scada.py
+++ b/gw_spaceheat/actors/scada.py
@@ -495,18 +495,37 @@ class Scada(PrimeActor, ScadaInterface):
             self.log("Admin Wakes Up")
 
     def process_ally_gives_up(self, from_node: ShNode, payload: AllyGivesUp) -> None:
-        # AutoState transition: AllyGivesUp: LeafTransactiveNode -> LocalControl
+        """Handle LeafAlly relinquishing supervisory authority.
+
+        Effects:
+        - Transitions auto_state from LeafTransactiveNode -> LocalControl
+        - If an active contract exists, sends a terminating heartbeat to the Ltn
+        - Cancels any outstanding contract timing task
+
+        Note:
+        LeafAlly may give up authority even when no active contract heartbeat
+        exists (for example during grace period or after contract completion).
+        In that case we still transition to LocalControl but do not send a
+        terminating heartbeat.
+        """
         self.auto_trigger(MainAutoEvent.AllyGivesUp)
+
         self.log(f"LeafAlly giving up: {payload.Reason}")
-        self.log("Sending termination hb to Scada. State: LeafTransactiveNode -> LocalControl")
-        hb = self.contract_handler.scada_terminates_contract_hb(cause=f"Ally Gives up: {payload.Reason}")
-        
-        self.contract_handler.latest_scada_hb = hb
-        self.contract_handler.store_heartbeat()
-        self.contract_handler.flush_latest_scada_hb()
     
-        self._send_to(self.ltn, hb)
-        # Cancel any existing warning task
+        if self.contract_handler.latest_scada_hb:
+            self.log("Sending termination hb to Scada. State: LeafTransactiveNode -> LocalControl")
+            hb = self.contract_handler.scada_terminates_contract_hb(cause=f"Ally Gives up: {payload.Reason}")
+        
+            self.contract_handler.latest_scada_hb = hb
+            self.contract_handler.store_heartbeat()
+            self.contract_handler.flush_latest_scada_hb()
+    
+            self._send_to(self.ltn, hb)
+        else:
+            self.log(
+                "No active contract heartbeat while processing AllyGivesUp"
+            )
+
         if hasattr(self, 'contract_task'):
             self.contract_task.cancel()
 


### PR DESCRIPTION
The intended fallback is that SCADA may remain in `LeafTransactiveNode` during the contract grace period, but once that grace period ends it should transition back to `LocalControl`. That check lives in `enforce_auto_state_consistency()`: when `auto_state == LeafTransactiveNode`, it calls `in_grace_period()`, and if false, triggers `ContractGracePeriodEnds`.

  That path was broken for BufferOnly systems. `enforce_auto_state_consistency()` was effectively written around the AllTanks LeafAlly dormant state, so BufferOnly LeafAlly state was not handled correctly. As a result, SCADA could remain in `LeafTransactiveNode` after the grace period ended, leaving LeafAlly awake in its last state, such as `HpOff`, and preventing LocalControl from resuming.

  This change makes `enforce_auto_state_consistency()` choose the correct LeafAlly dormant state based on `SeasonalStorageMode`, so the grace-period expiry path works for both AllTanks and BufferOnly.

  The PR also fixes a second related wedge: LeafAlly now sends `AllyGivesUp` whenever it is awake and the system is cold, not only when it still has an active contract heartbeat. SCADA now handles `AllyGivesUp` with no active `latest_scada_hb` by still transitioning from `LeafTransactiveNode` to `LocalControl`, while skipping the contract termination heartbeat because there is no active contract to terminate.

  Recommended tests to add:

  - BufferOnly: SCADA in `LeafTransactiveNode`, `latest_scada_hb is None`, `prev` is past grace period, LeafAlly not dormant. Calling
  `enforce_auto_state_consistency()` should transition SCADA to `LocalControl`, wake LocalControl, and send `GoDormant` to LeafAlly.
  - BufferOnly: SCADA in `LeafTransactiveNode`, expired previous contract still within grace period, `latest_scada_hb is None`. Calling
  `enforce_auto_state_consistency()` should not transition yet.
  - AllTanks: same two grace-period tests, to confirm the generalized dormant-state logic did not regress the existing path.
  - `process_ally_gives_up()` with an active `latest_scada_hb`: should transition to `LocalControl`, store/flush a terminating heartbeat, send it to LTN, and
  cancel `contract_task`.
  - `process_ally_gives_up()` with no active `latest_scada_hb`: should still transition to `LocalControl`, should not attempt to create/store/send a terminating
  heartbeat, and should cancel `contract_task`.
  - LeafAlly BufferOnly and AllTanks main-loop behavior: when LeafAlly is awake and `is_system_cold()` is true, it should send `AllyGivesUp` even when
  `contract_hb is None`.