### PR TITLE
Add back a much-pruned docs folder

### DIFF
--- a/docs/editor-setup.md
+++ b/docs/editor-setup.md
@@ -1,0 +1,109 @@
+# Editor Setup
+
+This document covers optional editor tooling for contributors working on `gridworks-scada`.
+
+None of the tools below are required to run the code or contribute changes, but they can improve feedback while developing.
+
+---
+
+## Recommended Editor
+
+Many contributors use VS Code, though any Python-capable editor is fine.
+
+---
+
+## Ruff (Linting Feedback)
+
+The repository includes configuration for  BsCode.
+
+Install Ruff in your editor to get inline warnings and style feedback while editing.
+
+From the command line:
+
+    ruff check
+
+Notes:
+
+- Ruff is currently advisory.
+- The full repository may not yet pass all configured checks.
+- Use it as helpful feedback, not as a blocker.
+
+---
+
+## VS Code + Ruff Extension
+
+If using VS Code:
+
+1. Install the Ruff extension.
+2. Enable it for this workspace if desired.
+3. Use Problems / Diagnostics panes for live feedback.
+
+---
+
+## Python Type Checking
+
+Basic type checking can be useful for catching mistakes early.
+
+If using :contentReference[oaicite:3]{index=3} with Pylance:
+
+1. Open Settings
+2. Search for `python.analysis.typeCheckingMode`
+
+Suggested settings:
+
+- `basic` — good default
+- `strict` — stronger checks, may be noisy in parts of the repo
+
+Because portions of the repository are still evolving, workspace-level or user-level tuning may be helpful.
+
+---
+
+## Recommended Python Interpreter
+
+Use the repo virtual environment created by:
+
+    ./tools/mkenv.sh
+
+Then point your editor at:
+
+    gw_spaceheat/venv/bin/python
+
+This ensures imports and installed dependencies match local development.
+
+---
+
+## Import Resolution
+
+If your editor has trouble resolving local modules, ensure the repository root is opened as the workspace folder and that the virtual environment is selected.
+
+Some contributors also set `PYTHONPATH` when working in shell sessions.
+
+---
+
+## Minimal Setup
+
+If you want the quickest useful setup:
+
+1. Select the repo virtual environment
+2. Enable Ruff
+3. Use basic type checking
+
+That is enough for most contributors.
+
+---
+
+## Troubleshooting
+
+### Editor shows missing imports
+
+Usually caused by selecting the wrong interpreter. Re-select:
+
+    gw_spaceheat/venv/bin/python
+
+### Too many warnings
+
+Reduce type checking strictness or disable specific extensions temporarily.
+
+### CLI works but editor is confused
+
+The shell environment and editor interpreter are likely different. Align them first.

--- a/docs/provisioning.md
+++ b/docs/provisioning.md
@@ -1,0 +1,257 @@
+# Provisioning a SCADA Node
+
+This guide covers preparing a new Raspberry Pi (or replacement device) to operate as a real GridWorks SCADA.
+
+Use this document when bringing a site online, replacing failed hardware, or re-provisioning an existing installation.
+
+This guide is **not** for local development or pytest. For those workflows, use the main README.
+
+---
+## 1. Make SD card
+
+TODO: ADD
+
+## 2. Install the SCADA Repository
+
+Choose an installation location such as:
+
+    ~/gridworks-scada
+
+Clone the repository and enter it:
+
+    git clone <repo-url>
+    cd gridworks-scada
+
+Create the Python environment:
+
+    ./tools/mkenv-pi.sh
+
+Activate it if needed:
+
+    source gw_spaceheat/venv/bin/activate
+
+Install the CLI:
+
+    ./tools/install-gws.sh
+
+---
+
+## 3. Assign GNode and make Layout
+
+Every deployed SCADA should correspond to a known GridWorks GNode
+
+That identity will affect:
+
+- certificates
+- hardware layout
+- broker authorization
+- naming inside logs and telemetry
+
+Confirm which site this unit is intended to become before continuing.
+
+---
+
+## 4. Retrieve Production Credentials
+
+Production MQTT credentials and certificates are typically installed using:
+
+    python gw_spaceheat/getkeys.py --help
+
+This tool is used to place the required credentials in the expected filesystem locations.
+
+Typical prerequisites include:
+
+- SSH access for certificate retrieval
+- configured `rclone`
+- knowledge of the target site identity
+- operational access permissions
+
+If this process fails, coordinate with whoever manages deployment credentials.
+
+---
+
+## 5. Configure Local Environment
+
+Create or update the local environment file if required:
+
+    cp .env-template .env
+
+Make sure all heater-specific `.env` variables are set correctly,
+Use the correct broker endpoints
+
+```
+SCADA_GRIDWORKS_MQTT__HOST = "hw1-1.electricity.works"
+SCADA_GRIDWORKS_MQTT__USERNAME = "smqPublic"
+SCADA_GRIDWORKS_MQTT__PASSWORD = "GET PASSWD"
+```
+
+- logging preferences
+- broker endpoints
+- deployment-specific overrides
+
+To inspect the resolved configuration:
+
+    gws config
+
+This is often the fastest way to verify active settings.
+
+---
+
+## 6. Hardware Layout
+
+Confirm the correct hardware layout file is present.
+
+Typical location:
+
+    ~/.config/gridworks/scada/hardware-layout.json
+
+To inspect the loaded layout:
+
+    gws layout show
+
+If replacing an existing node, ensure the correct site layout is restored before startup.
+
+---
+
+## 7. Install as a Service
+
+Install the systemd services:
+
+    ./service/install
+
+Check status:
+
+    gwstatus
+
+Start services:
+
+    gwstart
+
+Pause the main service temporarily:
+
+    gwpause
+
+Stop services:
+
+    gwstop
+
+---
+
+## 8. First Boot Validation
+
+After starting the service, verify:
+
+- service is running
+- no restart loop
+- upstream broker connection succeeds
+- expected actors initialize
+- sensors/components appear healthy
+- logs do not show repeated certificate or config errors
+
+Useful commands:
+
+    gwstatus
+
+and:
+
+    journalctl -u gwspaceheat.service -f
+
+(service name may vary by deployment)
+
+---
+
+## 9. Connectivity Checks
+
+If the node does not connect upstream, check:
+
+- internet access
+- DNS resolution
+- firewall restrictions
+- system clock correctness
+- certificate validity
+- correct site identity
+- broker hostname in config
+
+Incorrect system time can break TLS.
+
+---
+
+## 10. Replacing a Failed Raspberry Pi
+
+Typical replacement process:
+
+1. Prepare new Pi
+2. Install repo
+3. Restore correct hardware layout
+4. Reinstall credentials for the same site identity
+5. Install/start service
+6. Validate telemetry and controls
+
+Be careful not to provision two live devices with the same identity unless intentionally coordinated.
+
+---
+
+## 11. Safe Bring-Up Recommendations
+
+When possible:
+
+- start with pumps/loads electrically safe
+- verify sensors first
+- verify relay outputs carefully
+- observe logs during first runtime
+- confirm expected control behavior before leaving site unattended
+
+---
+
+## 12. Troubleshooting
+
+### Service Restarts Repeatedly
+
+Usually caused by:
+
+- bad `.env`
+- missing hardware layout
+- Python environment problems
+- missing credentials
+
+### Broker Authentication Failure
+
+Usually caused by:
+
+- wrong certs
+- expired certs
+- hostname mismatch
+- wrong site identity
+
+### Hardware Missing
+
+Check:
+
+- USB connections
+- I2C enabled
+- permissions
+- wiring
+- expected component IDs
+
+### Wrong Site Appears in Logs
+
+Likely wrong credentials, wrong config, or reused files from another deployment.
+
+---
+
+## 13. Operational Notes
+
+After provisioning, future maintenance is usually:
+
+- pull latest code
+- restart service
+- rotate credentials when needed
+- update hardware layout after physical changes
+
+---
+
+## Related Documents
+
+- `README.md` — local development and testing
+- `docs/tls.md` — certificate and TLS details
+- `docs/editor-setup.md` — contributor editor tooling

--- a/docs/tls.md
+++ b/docs/tls.md
@@ -1,0 +1,123 @@
+# TLS and Certificates
+
+GridWorks supports TLS-secured MQTT communication for CI, integration testing, and production deployments.
+
+For most local SCADA development and normal `pytest` runs, TLS is **not required**. Local tests default to the cleartext broker configuration described in the main README.
+
+---
+
+## Start Here: `gridworks-cert`
+
+Certificate generation, local certificate authorities, and related tooling are maintained in the sibling repository:
+
+[gridworks-cert]((https://github.com/thegridelectric/gridworks-cert/README.md))
+
+If you need to create or troubleshoot certificates, begin there first.
+
+That repository is the source of truth for:
+
+- local Certificate Authority setup
+- broker certificates
+- client certificates
+- `gwcert` usage
+- certificate directory conventions
+
+---
+
+## When TLS Is Typically Needed
+
+Use TLS when working on:
+
+- CI certificate paths
+- broker authentication behavior
+- production-like local integration testing
+- Raspberry Pi deployments using secured MQTT
+- real GridWorks broker connectivity
+
+For standard unit tests and most local SCADA-only work, use the non-TLS local broker setup instead.
+
+---
+
+## Local Certificate Workflow (Example)
+
+Typical workflow:
+
+1. Create or initialize the local CA in `gridworks-cert`
+2. Generate broker certificates
+3. Generate client certificates for SCADA / LTN
+4. Configure broker TLS listeners
+5. Point `.env` or runtime settings at the generated cert paths
+
+Exact commands may evolve, so refer to `gridworks-cert` documentation first.
+
+---
+
+## Example: Test LTN Certificate
+
+    gwcert key add --certs-dir $HOME/.config/gridworks/ltn/certs scada_mqtt
+    cp $HOME/.local/share/gridworks/ca/ca.crt \
+       $HOME/.config/gridworks/ltn/certs/scada_mqtt
+
+## Example: Test SCADA Certificate
+
+    gwcert key add --certs-dir $HOME/.config/gridworks/scada/certs gridworks_mqtt
+    cp $HOME/.local/share/gridworks/ca/ca.crt \
+       $HOME/.config/gridworks/scada/certs/gridworks_mqtt
+
+---
+
+## Example TLS Smoke Test
+
+Subscriber:
+
+    mosquitto_sub -h localhost -p 8883 -t foo \
+      --cafile $HOME/.config/gridworks/ltn/certs/scada_mqtt/ca.crt \
+      --cert $HOME/.config/gridworks/ltn/certs/scada_mqtt/scada_mqtt.crt \
+      --key $HOME/.config/gridworks/ltn/certs/scada_mqtt/private/scada_mqtt.pem
+
+Publisher:
+
+    mosquitto_pub -h localhost -p 8883 -t foo -m '{"bar":1}' \
+      --cafile $HOME/.config/gridworks/scada/certs/gridworks_mqtt/ca.crt \
+      --cert $HOME/.config/gridworks/scada/certs/gridworks_mqtt/gridworks_mqtt.crt \
+      --key $HOME/.config/gridworks/scada/certs/gridworks_mqtt/private/gridworks_mqtt.pem
+
+If TLS is working, the subscriber should receive:
+
+    {"bar":1}
+
+---
+
+## Production Credential Provisioning
+
+For provisioning keys used with the real GridWorks broker, see:
+
+    gw_spaceheat/getkeys.py --help
+
+This typically requires:
+
+- access credentials
+- remote file sync tooling (such as rclone)
+- target device connectivity
+- correct broker identity / deployment inputs
+
+---
+
+## Troubleshooting
+
+### TLS Handshake Errors
+
+Usually caused by:
+
+- wrong CA file
+- hostname mismatch
+- expired certificates
+- incorrect key/cert pairing
+
+### Local Tests Suddenly Expect TLS
+
+Check whether your `.env` or shell environment is overriding the repo test defaults.
+
+### Unsure Where to Begin
+
+Go back to **gridworks-cert** first.


### PR DESCRIPTION
Some basic instructions for provisioning an SD card, setting up editors/linting tools and a bit more regarding TLS certs.  Pruned back from the old readme and old docs folder.